### PR TITLE
Set proper headers in upload requests

### DIFF
--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -201,7 +201,17 @@ export class Uploader {
 
 					// Init request queue
 					const request = () => {
-						return uploadData(`${tempUrl}/${chunk+1}`, blob, upload.signal, () => this.updateStats(), destinationFile)
+						return uploadData(
+							`${tempUrl}/${chunk+1}`,
+							blob,
+							upload.signal,
+							() => this.updateStats(),
+							destinationFile,
+							{
+								'X-OC-Mtime': file.lastModified,
+								'OC-Total-Length': file.size,
+							}
+						)
 							// Update upload progress on chunk completion
 							.then(() => { upload.uploaded = upload.uploaded + maxChunkSize })
 							.catch((error) => {
@@ -261,7 +271,16 @@ export class Uploader {
 				const blob = await getChunk(file, 0, upload.size)
 				const request = async () => {
 					try {
-						upload.response = await uploadData(destinationFile, blob, upload.signal, () => this.updateStats())
+						upload.response = await uploadData(
+							destinationFile,
+							blob,
+							upload.signal,
+							() => this.updateStats(),
+							undefined,
+							{
+								'X-OC-Mtime': file.lastModified,
+							}
+						)
 
 						// Update progress
 						upload.uploaded = upload.size

--- a/lib/utils/upload.ts
+++ b/lib/utils/upload.ts
@@ -12,7 +12,7 @@ type UploadData = Blob | (() => Promise<Blob>)
 /**
  * Upload some data to a given path
  */
-export const uploadData = async function(url: string, uploadData: UploadData, signal: AbortSignal, onUploadProgress = () => {}, destinationFile: string | undefined = undefined): Promise<AxiosResponse> {
+export const uploadData = async function(url: string, uploadData: UploadData, signal: AbortSignal, onUploadProgress = () => {}, destinationFile: string | undefined = undefined, headers: any = undefined): Promise<AxiosResponse> {
 	let data: Blob
 
 	if (uploadData instanceof Blob) {
@@ -21,7 +21,10 @@ export const uploadData = async function(url: string, uploadData: UploadData, si
 		data = await uploadData()
 	}
 
-	const headers = destinationFile ? { Destination: destinationFile } : undefined
+	if (destinationFile) {
+		headers ??= {}
+		headers.Destination = destinationFile
+	}
 
 	return await axios.request({
 		method: 'PUT',


### PR DESCRIPTION
Currently, when you upload a file, the last modified time is not forwarded to the server, so it becomes the current time.

See https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html#request-headers

Can we merge the `destinationFile` and `headers` params?