### PR TITLE
fix: Do not block if the filetype is unknown to the browser

### DIFF
--- a/__tests__/utils/upload.spec.ts
+++ b/__tests__/utils/upload.spec.ts
@@ -35,11 +35,14 @@ describe('Get chunk from file', () => {
 		expect(chunk.size).toBe(10 * 1024 * 1024)
 	})
 
-	test('Chunking an invalid file', () => {
+	test('Chunking an invalid file', async () => {
 		const blob = new Blob([new ArrayBuffer(5 * 1024 * 1024)])
 		const file = new File([blob as BlobPart], 'image.jpg')
 
-		expect(getChunk(file, 0, 10 * 1024 * 1024)).rejects.toEqual(new Error('Unknown file type'))
+		const chunk = await getChunk(file, 0, 10 * 1024 * 1024)
+		expect(chunk.size).toBe(5 * 1024 * 1024)
+		expect(chunk.type).toBe('application/octet-stream')
+
 	})
 })
 

--- a/lib/utils/upload.ts
+++ b/lib/utils/upload.ts
@@ -42,10 +42,6 @@ export const uploadData = async function(url: string, uploadData: UploadData, si
  * garbage collection
  */
 export const getChunk = function(file: File, start: number, length: number): Promise<Blob> {
-	if (!file.type) {
-		return Promise.reject(new Error('Unknown file type'))
-	}
-
 	// Since we use a global FileReader, we need to only read one chunk at a time
 	return readerLimit(() => new Promise((resolve, reject) => {
 		reader.onload = () => {


### PR DESCRIPTION
Fix #926 