### PR TITLE
Fix "Add" label to "New"

### DIFF
--- a/cypress/components/UploadPicker.cy.ts
+++ b/cypress/components/UploadPicker.cy.ts
@@ -25,7 +25,7 @@ describe('UploadPicker rendering', () => {
 		}
 		cy.mount(UploadPicker, { propsData })
 		cy.get('[data-cy-upload-picker]').should('be.visible')
-		cy.get('[data-cy-upload-picker]').should('have.text', 'Add')
+		cy.get('[data-cy-upload-picker]').should('have.text', 'New')
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').should('exist')
 	})
 
@@ -54,7 +54,7 @@ describe('UploadPicker valid uploads', () => {
 		cy.mount(UploadPicker, { propsData }).as('uploadPicker')
 
 		// Label is displayed before upload
-		cy.get('[data-cy-upload-picker]').should('have.text', 'Add')
+		cy.get('[data-cy-upload-picker]').should('have.text', 'New')
 
 		// Check and init aliases
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
@@ -91,7 +91,7 @@ describe('UploadPicker valid uploads', () => {
 			.should('be.visible')
 
 		// Label gets hidden during upload
-		cy.get('[data-cy-upload-picker]').should('not.have.text', 'Add')
+		cy.get('[data-cy-upload-picker]').should('not.have.text', 'New')
 
 		cy.wait('@upload').then(() => {
 			cy.get('[data-cy-upload-picker] .upload-picker__progress')
@@ -99,7 +99,7 @@ describe('UploadPicker valid uploads', () => {
 				.should('not.be.visible')
 
 			// Label is displayed again after upload
-			cy.get('[data-cy-upload-picker] button').should('have.text', 'Add')
+			cy.get('[data-cy-upload-picker] button').should('have.text', 'New')
 		})
 	})
 })

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -22,9 +22,6 @@ msgstr ""
 msgid "a few seconds left"
 msgstr ""
 
-msgid "Add"
-msgstr ""
-
 msgid "Cancel uploads"
 msgstr ""
 
@@ -41,6 +38,9 @@ msgid "If you select both versions, the copied file will have a number added to 
 msgstr ""
 
 msgid "Last modified date unknown"
+msgstr ""
+
+msgid "New"
 msgstr ""
 
 msgid "New version"

--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -143,7 +143,7 @@ export default Vue.extend({
 
 	data() {
 		return {
-			addLabel: t('Add'),
+			addLabel: t('New'),
 			cancelLabel: t('Cancel uploads'),
 			uploadLabel: t('Upload files'),
 


### PR DESCRIPTION
As discussed in chat with @szaimen

This is fixing a regression because the label we introduced was called "New" and is supposed to be that cause most actions in it are "New …".