### PR TITLE
chore(deps): specify Vue to remove extraneous dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "p-cancelable": "^4.0.1",
         "p-limit": "^5.0.0",
         "p-queue": "^7.4.1",
-        "simple-eta": "^3.0.2"
+        "simple-eta": "^3.0.2",
+        "vue": "^2.7.15"
       },
       "devDependencies": {
         "@cypress/vue2": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "p-cancelable": "^4.0.1",
     "p-limit": "^5.0.0",
     "p-queue": "^7.4.1",
-    "simple-eta": "^3.0.2"
+    "simple-eta": "^3.0.2",
+    "vue": "^2.7.15"
   },
   "peerDependencies": {
     "@nextcloud/vue": "^8.0.0-beta || ^8.0.0"


### PR DESCRIPTION
Components import `vue`:
```js
import Vue from 'vue'
```

However, `vue` is not a dependency of this package which makes it an **extraneous dependency**. So `rollup` does not consider it as an external dependency and builds copy of Vue into the bundle.

Usually it would result only in increasing the size of the bundle. But this component is used in `NcBreadcrubms` that has some nodes tree manipulation in the render function. Then it has a mix of components in a tree that are from different copies of Vue. It leads Vue to fail `isUpdatingChildComponent` check when it actually updates "a child component" and spam console with **100s of errors** in the dev build of Nextcloud:

![image](https://github.com/nextcloud-libraries/nextcloud-upload/assets/25978914/b2bce6b1-8c52-418f-9143-0958f1c1bd05)

This PR specifies Vue as a dependency to remove the extraneous dependency. And clears the console =D

P.S. ESLint rule may safe from it: [no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-extraneous-dependencies.md)
