### PR TITLE
fix(UploadPicker): Add label for upload progress and connect progress with description [a11y]

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -75,6 +75,9 @@ msgstr ""
 msgid "Upload files"
 msgstr ""
 
+msgid "Upload progress"
+msgstr ""
+
 msgid "Which files do you want to keep?"
 msgstr ""
 

--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -45,12 +45,14 @@
 			</NcActionButton>
 		</NcActions>
 
-		<!-- Progressbar and status, hidden by css -->
-		<div class="upload-picker__progress">
-			<NcProgressBar :error="hasFailure"
+		<!-- Progressbar and status -->
+		<div v-show="isUploading" class="upload-picker__progress">
+			<NcProgressBar :aria-label="progressLabel"
+				:aria-describedby="progressTimeId"
+				:error="hasFailure"
 				:value="progress"
 				size="medium" />
-			<p>{{ timeLeft }}</p>
+			<p :id="progressTimeId">{{ timeLeft }}</p>
 		</div>
 
 		<!-- Cancel upload button -->
@@ -146,6 +148,8 @@ export default Vue.extend({
 			addLabel: t('New'),
 			cancelLabel: t('Cancel uploads'),
 			uploadLabel: t('Upload files'),
+			progressLabel: t('Upload progress'),
+			progressTimeId: `nc-uploader-progress-${Math.random().toString(36).slice(7)}`,
 
 			eta: null,
 			timeLeft: '',


### PR DESCRIPTION
* Resolves #1001 

All form elements - and this includes also the `progress` element - need a label this is now added.
Also semantically connecting the description with the progress by using `aria-describedby`