### PR TITLE
fix: Add upload progress for non-chunked uploads

### DIFF
--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -295,7 +295,10 @@ export class Uploader {
 							encodedDestinationFile,
 							blob,
 							upload.signal,
-							() => this.updateStats(),
+							(event) => {
+								upload.uploaded = upload.uploaded + event.bytes
+								this.updateStats()
+							},
 							undefined,
 							{
 								'X-OC-Mtime': file.lastModified / 1000,

--- a/lib/utils/upload.ts
+++ b/lib/utils/upload.ts
@@ -1,4 +1,4 @@
-import type { AxiosResponse } from 'axios'
+import type { AxiosProgressEvent, AxiosResponse } from 'axios'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
@@ -22,7 +22,7 @@ export const uploadData = async function(
 	url: string,
 	uploadData: UploadData,
 	signal: AbortSignal,
-	onUploadProgress = () => {},
+	onUploadProgress:(event: AxiosProgressEvent) => void = () => {},
 	destinationFile: string | undefined = undefined,
 	headers: Record<string, string|number> = {},
 ): Promise<AxiosResponse> {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/43335

For chunked uploads we have a progress after every finished chunk. But for non-chunked uploads we do not have any progress - even for big uploads.
To fix this I added the uploaded bytes to the upload progress of non-chunked uploads.