### PR TITLE
fix: migrate conflictpicker to NcDialog and remove incorrect semantic closing icon

### DIFF
--- a/cypress/components/ConflictPicker.cy.ts
+++ b/cypress/components/ConflictPicker.cy.ts
@@ -36,11 +36,11 @@ describe('ConflictPicker rendering', { testIsolation: true }, () => {
 		cy.get('[data-cy-conflict-picker-fieldset="all"]').should('exist')
 		cy.get('[data-cy-conflict-picker-fieldset="image.jpg"]').should('exist')
 
-		cy.get('[data-cy-conflict-picker-skip]').should('be.visible')
+		cy.get('[data-cy-conflict-picker-skip]').scrollIntoView().should('be.visible')
 		cy.get('[data-cy-conflict-picker-submit]').should('be.visible')
 
 		// Force close and cancel
-		cy.get('[data-cy-conflict-picker] .modal-container__close').click({ force: true })
+		cy.get('[data-cy-conflict-picker-skip]').click({ force: true })
 	})
 })
 

--- a/lib/components/ConflictPicker.vue
+++ b/lib/components/ConflictPicker.vue
@@ -2,14 +2,13 @@
 	<NcDialog class="conflict-picker"
 		data-cy-conflict-picker
 		:close-on-click-outside="false"
-		:canClose="false"
+		:can-close="false"
 		:show="opened"
+		:name="name"
 		size="large"
 		@close="onCancel">
 		<!-- Header -->
 		<div class="conflict-picker__header">
-			<h2 class="conflict-picker__title" v-text="name" />
-
 			<!-- Description -->
 			<p id="conflict-picker-description" class="conflict-picker__description">
 				{{ t('Which files do you want to keep?') }}<br>

--- a/lib/components/ConflictPicker.vue
+++ b/lib/components/ConflictPicker.vue
@@ -1,7 +1,8 @@
 <template>
-	<NcModal class="conflict-picker"
+	<NcDialog class="conflict-picker"
 		data-cy-conflict-picker
 		:close-on-click-outside="false"
+		:canClose="false"
 		:show="opened"
 		size="large"
 		@close="onCancel">
@@ -67,7 +68,7 @@
 				{{ t('Continue') }}
 			</NcButton>
 		</div>
-	</NcModal>
+	</NcDialog>
 </template>
 
 <script lang="ts">
@@ -81,7 +82,7 @@ import Vue from 'vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
-import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Close from 'vue-material-design-icons/Close.vue'
 
@@ -99,7 +100,7 @@ export default Vue.extend({
 		Close,
 		NcButton,
 		NcCheckboxRadioSwitch,
-		NcModal,
+		NcDialog,
 		NodesPicker,
 	},
 
@@ -372,7 +373,7 @@ export default Vue.extend({
 		position: sticky;
 		z-index: 10;
 		top: 0;
-		padding: var(--margin);
+		padding: 0 var(--margin);
 		padding-bottom: 0;
 	}
 


### PR DESCRIPTION
Resolves #1095

**Summary**
* Before, the ConflictPicker was built using NcModal. This is good, but migrating to NcDialog will allow for more features if needed in the future, and we also can remove the "x" button
* The reason this PR was opened was because we could not click it, but after looking more into it, I do not believe that the conflict picker should have it. Previously, it did not even close the modal anyways (it would open it again), and semantically, because a conflict is happening, I believe that the user should choose between a file, or ignore importing the file.

**Video**

https://github.com/nextcloud-libraries/nextcloud-upload/assets/110193237/0c1c5e86-ef57-44a1-bf9f-dc21e16a3ef1



