### PR TITLE
fix(upload): Do not read chunks into memory but just stream file chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
         "p-cancelable": "^4.0.1",
-        "p-limit": "^5.0.0",
         "p-queue": "^8.0.0",
         "simple-eta": "^3.0.2"
       },
@@ -14678,6 +14677,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
       "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -19056,6 +19056,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
       "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
     "p-cancelable": "^4.0.1",
-    "p-limit": "^5.0.0",
     "p-queue": "^8.0.0",
     "simple-eta": "^3.0.2"
   },


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/43627

Instead of reading file chunks into memory and then upload those chunks, we should rather just slice the file and stream it for uploading. This prevents browsers to sky rocket the memory consumption.

We no longer need p-limit so drop that dependency.

---

You can test this by uploading a large file and monitor the process memory of your browser. Please note that Firefox has a browser bug: As long as the dev tools are open the request data is not freed so if you have the dev tools open you will still suffer this issue. 