### PR TITLE
fix: Drop dependency on moment.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@nextcloud/files": "^3.1.1",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/logger": "^2.7.0",
-        "@nextcloud/moment": "^1.3.1",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "axios": "^1.6.8",
@@ -3844,28 +3843,6 @@
       "engines": {
         "node": "^20.0.0",
         "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/moment": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.1.tgz",
-      "integrity": "sha512-+1CtYlc4Lu4soa1RKXvUsTJdsHS0kHUCzNBtb02BADMY5PMGUTCiCQx5xf1Ez15h2ehuwg0vESr8VyKem9sGAQ==",
-      "dependencies": {
-        "@nextcloud/l10n": "^2.2.0",
-        "moment": "^2.30.1",
-        "node-gettext": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/moment/node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@nextcloud/paths": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@nextcloud/files": "^3.1.1",
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/logger": "^2.7.0",
-    "@nextcloud/moment": "^1.3.1",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "axios": "^1.6.8",


### PR DESCRIPTION
* Resolves #1149 

Moment.js is pretty heavy and also deprecated - not recommended for new projects. Instead we can use the functions from `@nextcloud/vue`