### PR TITLE
Added retry capability for uploading files

### DIFF
--- a/__tests__/utils/upload.spec.ts
+++ b/__tests__/utils/upload.spec.ts
@@ -78,6 +78,10 @@ describe('Initialize chunks upload temporary workspace', () => {
 		expect(axiosMock.request).toHaveBeenCalledWith({
 			method: 'MKCOL',
 			url,
+			'axios-retry': {
+				retries: 5,
+				retryDelay: expect.any(Function),
+			},
 		})
 	})
 
@@ -105,6 +109,10 @@ describe('Initialize chunks upload temporary workspace', () => {
 			headers: {
 				Destination: 'https://cloud.domain.com/remote.php/dav/files/test/image.jpg',
 			},
+			'axios-retry': {
+				retries: 5,
+				retryDelay: expect.any(Function),
+			},
 		})
 	})
 })
@@ -129,6 +137,10 @@ describe('Upload data', () => {
 			onUploadProgress,
 			headers: {
 				'Content-Type': 'application/octet-stream',
+			},
+			'axios-retry': {
+				retries: 5,
+				retryDelay: expect.any(Function),
 			},
 		})
 	})
@@ -155,6 +167,10 @@ describe('Upload data', () => {
 			headers: {
 				'Content-Type': 'application/octet-stream',
 			},
+			'axios-retry': {
+				retries: 5,
+				retryDelay: expect.any(Function),
+			},
 		})
 	})
 
@@ -178,6 +194,10 @@ describe('Upload data', () => {
 			headers: {
 				Destination: url,
 				'Content-Type': 'application/octet-stream',
+			},
+			'axios-retry': {
+				retries: 5,
+				retryDelay: expect.any(Function),
 			},
 		})
 	})

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,11 +8,6 @@ const viteConfig = await createAppConfig({}, {
 	replace: {
 		__TRANSLATIONS__: '[]',
 	},
-	config: {
-		optimizeDeps: {
-			entries: ['cypress/**/*'],
-		},
-	},
 })({ mode: 'development', command: 'serve' })
 
 viteConfig.build!.rollupOptions = undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "axios": "^1.7.2",
+        "axios-retry": "^4.4.0",
         "crypto-browserify": "^3.12.0",
         "p-cancelable": "^4.0.1",
         "p-queue": "^8.0.0",
@@ -3559,6 +3560,17 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.4.0.tgz",
+      "integrity": "sha512-yewTKjzl6jSgc+2M7FCJ3LxRGgL1iiXHcj+E6h6xie6H1mTHr7yqaUroWIvVXG1UKSPwGDXxV05YxtGvrD6Paw==",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/bail": {
@@ -7554,6 +7566,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "axios": "^1.7.2",
+    "axios-retry": "^4.4.0",
     "crypto-browserify": "^3.12.0",
     "p-cancelable": "^4.0.1",
     "p-queue": "^8.0.0",


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-upload/issues/5

You can observe how it works on the video below. I've tested library changes using `npm link`. For failure simulation I've added next snippet to `remote.php`:

```php
	if ($_SERVER['REQUEST_METHOD'] === 'PUT' && random_int(0, 4) === 0) {
		throw new RemoteException('Service unavailable', 503);
	}

	sleep(2);
```

Also as you can see sha256 hash is the same for the uploaded and original files. So, files are not corrupted during retries. Later on we can configure how many retries available.

https://github.com/nextcloud-libraries/nextcloud-upload/assets/191082/ddf6aa32-20eb-412f-89ee-08b8f9549962