### PR TITLE
fix: Use other menu entries instead of new ones twice

### DIFF
--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -74,7 +74,7 @@
 			<!-- other file entries -->
 			<template v-if="menuEntriesOther.length > 0">
 				<NcActionSeparator />
-				<NcActionButton v-for="entry in menuEntriesNew"
+				<NcActionButton v-for="entry in menuEntriesOther"
 					:key="entry.id"
 					:icon="entry.iconClass"
 					:close-after-click="true"


### PR DESCRIPTION
Otherwise the files app displays the wrong entries twice 🙈 