### PR TITLE
export skipped when file conflict is skipped

### DIFF
--- a/cypress/components/ConflictPicker.cy.ts
+++ b/cypress/components/ConflictPicker.cy.ts
@@ -262,7 +262,7 @@ describe('ConflictPicker resolving', () => {
 			mtime: new Date('2021-01-01T00:00:00.000Z'),
 		})
 
-		const onSubmit = cy.spy().as('onSubmitSpy')
+		const onSkip = cy.spy().as('onSkipSpy')
 		const onCancel = cy.spy().as('onCancelSpy')
 		cy.mount(ConflictPicker, {
 			propsData: {
@@ -271,7 +271,7 @@ describe('ConflictPicker resolving', () => {
 				conflicts: images,
 			},
 			listeners: {
-				submit: onSubmit,
+				skip: onSkip,
 				cancel: onCancel,
 			},
 		})
@@ -280,11 +280,7 @@ describe('ConflictPicker resolving', () => {
 		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 3)
 		cy.get('[data-cy-conflict-picker-skip]').click()
 
-		cy.get('@onSubmitSpy').should('have.been.calledOnce').then((onSubmit) => {
-			const results = (onSubmit as unknown as sinon.SinonSpy).firstCall.args[0]
-			expect(results.selected).to.have.length(0)
-			expect(results.renamed).to.have.length(0)
-		})
+		cy.get('@onSkipSpy').should('have.been.calledOnce')
 		cy.get('@onCancelSpy').should('not.have.been.called')
 	})
 })

--- a/lib/components/ConflictPicker.vue
+++ b/lib/components/ConflictPicker.vue
@@ -286,10 +286,7 @@ export default defineComponent({
 		onSkip() {
 			logger.debug('Conflict skipped. Ignoring all conflicting files')
 			this.opened = false
-			this.$emit('submit', {
-				selected: [],
-				renamed: [],
-			} as ConflictResolutionResult<File>)
+			this.$emit('skip')
 		},
 
 		onSubmit() {
@@ -344,6 +341,7 @@ export default defineComponent({
 			this.$emit('submit', {
 				selected,
 				renamed,
+				skipped: false,
 			} as ConflictResolutionResult<File|Node|FileSystemEntry>)
 		},
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,6 +21,7 @@ let _uploader: Uploader | null = null
 export type ConflictResolutionResult<T extends File|FileSystemEntry|Node> = {
 	selected: T[],
 	renamed: T[],
+	skipped: boolean,
 }
 /**
  * Get an Uploader instance
@@ -104,6 +105,13 @@ export async function openConflictPicker<T extends File|FileSystemEntry|Node>(
 						picker.$destroy()
 						picker.$el?.parentNode?.removeChild(picker.$el)
 					},
+					skip() {
+						resolve({selected: [],renamed: [], skipped: true})
+
+						// Destroy the component
+						picker.$destroy()
+						picker.$el?.parentNode?.removeChild(picker.$el)
+					}
 				},
 			}),
 		})


### PR DESCRIPTION
required by: https://github.com/nextcloud/server/pull/46354

this PR will export an additional value ```skipped``` to indicate if the file conflict has been skipped rather than resolved. Before there seemed to be no way of telling the difference between skipping and selecting only the original file.

Both cases would return selected = [] and renamed = [] causing an issue in server when that skipping files would the delete the file that was moved.