### PR TITLE
feat: add cypress selectors for new menu entries

### DIFF
--- a/cypress/components/UploadPicker.cy.ts
+++ b/cypress/components/UploadPicker.cy.ts
@@ -306,10 +306,10 @@ describe('NewFileMenu handling', () => {
 			.should('exist')
 
 		cy.get('@menuButton').click()
-		cy.get('[data-cy-upload-picker-add]').should('have.length', 1)
-		cy.get('.upload-picker__menu-entry').should('have.length', 1)
+		cy.get('[data-cy-upload-picker-menu-entry="upload-file"]').should('have.length', 1)
+		cy.get('[data-cy-upload-picker-menu-entry="empty-file"]').should('have.length', 1)
 
-		cy.get('.upload-picker__menu-entry')
+		cy.get('[data-cy-upload-picker-menu-entry="empty-file"]')
 			.click()
 			.then(() => {
 				expect(entry.handler).to.be.called
@@ -328,13 +328,13 @@ describe('NewFileMenu handling', () => {
 			.should('exist')
 
 		cy.get('@menuButton').click()
-		cy.get('[data-cy-upload-picker-add]').should('have.length', 1)
-		cy.get('.upload-picker__menu-entry').should('have.length', 1)
+		cy.get('[data-cy-upload-picker-menu-entry="upload-file"]').should('have.length', 1)
+		cy.get('[data-cy-upload-picker-menu-entry="empty-file"]').should('have.length', 1)
 
 		// Close menu
 		cy.get('body').click()
-		cy.get('[data-cy-upload-picker-add]').should('not.be.visible')
-		cy.get('.upload-picker__menu-entry').should('not.be.visible')
+		cy.get('[data-cy-upload-picker-menu-entry="upload-file"]').should('not.be.visible')
+		cy.get('[data-cy-upload-picker-menu-entry="empty-file"]').should('not.be.visible')
 
 		cy.get('@component').then((component) => {
 			component.setDestination(new Folder({
@@ -350,8 +350,8 @@ describe('NewFileMenu handling', () => {
 		cy.get('[data-cy-upload-picker] .action-item__menutoggle')
 			.as('menuButton')
 			.should('not.exist')
-		cy.get('[data-cy-upload-picker-add]').should('have.length', 1)
-		cy.get('.upload-picker__menu-entry').should('not.exist')
+		cy.get('[data-cy-upload-picker-menu-entry="upload-file"]').should('have.length', 1)
+		cy.get('[data-cy-upload-picker-menu-entry="empty-file"]').should('not.exist')
 	})
 })
 

--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -12,6 +12,7 @@
 		<NcButton v-if="newFileMenuEntries && newFileMenuEntries.length === 0"
 			:disabled="disabled"
 			data-cy-upload-picker-add
+			data-cy-upload-picker-menu-entry="upload-file"
 			type="secondary"
 			@click="onTriggerPick()">
 			<template #icon>
@@ -29,7 +30,10 @@
 
 			<NcActionCaption :name="t('Upload from device')" />
 
-			<NcActionButton data-cy-upload-picker-add :close-after-click="true" @click="onTriggerPick()">
+			<NcActionButton data-cy-upload-picker-add
+				data-cy-upload-picker-menu-entry="upload-file"
+				:close-after-click="true"
+				@click="onTriggerPick()">
 				<template #icon>
 					<IconUpload :size="20" />
 				</template>
@@ -38,6 +42,7 @@
 			<NcActionButton v-if="canUploadFolders"
 				close-after-click
 				data-cy-upload-picker-add-folders
+				data-cy-upload-picker-menu-entry="upload-folder"
 				@click="onTriggerPick(true)">
 				<template #icon>
 					<IconFolderUpload style="color: var(--color-primary-element)" :size="20" />
@@ -50,6 +55,7 @@
 				:key="entry.id"
 				:icon="entry.iconClass"
 				:close-after-click="true"
+				:data-cy-upload-picker-menu-entry="entry.id"
 				class="upload-picker__menu-entry"
 				@click="entry.handler(destination, currentContent)">
 				<template v-if="entry.iconSvgInline" #icon>
@@ -66,6 +72,7 @@
 					:key="entry.id"
 					:icon="entry.iconClass"
 					:close-after-click="true"
+					:data-cy-upload-picker-menu-entry="entry.id"
 					class="upload-picker__menu-entry"
 					@click="entry.handler(destination, currentContent)">
 					<template v-if="entry.iconSvgInline" #icon>
@@ -82,6 +89,7 @@
 					:key="entry.id"
 					:icon="entry.iconClass"
 					:close-after-click="true"
+					:data-cy-upload-picker-menu-entry="entry.id"
 					class="upload-picker__menu-entry"
 					@click="entry.handler(destination, currentContent)">
 					<template v-if="entry.iconSvgInline" #icon>


### PR DESCRIPTION
It was missing before:
![image](https://github.com/user-attachments/assets/d61b9d02-d97e-451f-af63-8e99c0f50842)
