### PR TITLE
fix: Always request current content when triggering a menu entry

### DIFF
--- a/cypress/components/UploadPicker.cy.ts
+++ b/cypress/components/UploadPicker.cy.ts
@@ -10,13 +10,23 @@ import { generateRemoteUrl } from '@nextcloud/router'
 import { UploadPicker, getUploader } from '../../lib/index.ts'
 import { basename } from 'path'
 
-describe('UploadPicker rendering', () => {
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
+let state: string | undefined
+before(() => {
+	cy.window().then((win) => {
+		state = win.document.body.innerHTML
 	})
+})
+
+const resetDocument = () => {
+	if (state) {
+		cy.window().then((win) => {
+			win.document.body.innerHTML = state!
+		})
+	}
+}
+
+describe('UploadPicker rendering', () => {
+	afterEach(() => resetDocument())
 
 	it('Renders default UploadPicker', () => {
 		const propsData = {
@@ -66,12 +76,7 @@ describe('UploadPicker valid uploads', () => {
 		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
 	})
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Uploads a file', () => {
 		// Intercept single upload
@@ -117,12 +122,7 @@ describe('UploadPicker invalid uploads', { testIsolation: true }, () => {
 		getUploader(false, true)
 	})
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Fails a file if forbidden character', () => {
 		// Make sure we reset the destination
@@ -287,12 +287,7 @@ describe('NewFileMenu handling', () => {
 		addNewFileMenuEntry(entry)
 	})
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Open the New File Menu', () => {
 		// Mount picker
@@ -377,12 +372,7 @@ describe('UploadPicker valid uploads', () => {
 		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
 	})
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Uploads a file with chunking', () => {
 		// Init and reset chunk request spy
@@ -481,12 +471,7 @@ describe('Destination management', () => {
 		}),
 	}
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Upload then changes the destination', () => {
 		// Mount picker
@@ -557,12 +542,7 @@ describe('Root management', () => {
 		}),
 	}
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Upload then changes the root', () => {
 		// Mount picker
@@ -659,12 +639,7 @@ describe('UploadPicker notify testing', () => {
 		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
 	})
 
-	afterEach(() => {
-		// Make sure we clear the body
-		cy.window().then((win) => {
-			win.document.body.innerHTML = '<div data-cy-root></div>'
-		})
-	})
+	afterEach(() => resetDocument())
 
 	it('Uploads a file without chunking', () => {
 		const notify = cy.spy()

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -12,6 +12,8 @@
 
 		<!-- Nextcloud customizations -->
 		<link href="https://nextcloud.github.io/server/apps/theming/css/default.css" rel="stylesheet" />
+		<link href="https://nextcloud.github.io/server/core/css/server.css" rel="stylesheet" />
+		<link href="https://nextcloud.github.io/server/core/css/apps.css" rel="stylesheet" />
 		<script type="text/javascript">
 			// mocking the webroot for @nextcloud/router
 			window._oc_webroot = ''
@@ -25,6 +27,11 @@
 		</script>
 	</head>
 	<body>
-		<div data-cy-root></div>
+		<header id="header" style="height: var(--header-height); width: 100%; position: absolute;"></header>
+		<main id="content">
+		<div id="app-content">
+			<div data-cy-root></div>
+		</div>
+		</main>
 	</body>
 </html>

--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -57,7 +57,7 @@
 				:close-after-click="true"
 				:data-cy-upload-picker-menu-entry="entry.id"
 				class="upload-picker__menu-entry"
-				@click="entry.handler(destination, currentContent)">
+				@click="onClick(entry)">
 				<template v-if="entry.iconSvgInline" #icon>
 					<NcIconSvgWrapper :svg="entry.iconSvgInline" />
 				</template>
@@ -74,7 +74,7 @@
 					:close-after-click="true"
 					:data-cy-upload-picker-menu-entry="entry.id"
 					class="upload-picker__menu-entry"
-					@click="entry.handler(destination, currentContent)">
+					@click="onClick(entry)">
 					<template v-if="entry.iconSvgInline" #icon>
 						<NcIconSvgWrapper :svg="entry.iconSvgInline" />
 					</template>
@@ -91,7 +91,7 @@
 					:close-after-click="true"
 					:data-cy-upload-picker-menu-entry="entry.id"
 					class="upload-picker__menu-entry"
-					@click="entry.handler(destination, currentContent)">
+					@click="onClick(entry)">
 					<template v-if="entry.iconSvgInline" #icon>
 						<NcIconSvgWrapper :svg="entry.iconSvgInline" />
 					</template>
@@ -233,7 +233,6 @@ export default Vue.extend({
 			eta: null,
 			timeLeft: '',
 
-			currentContent: [] as Node[],
 			newFileMenuEntries: [] as Entry[],
 			uploadManager: getUploader(),
 		}
@@ -307,13 +306,6 @@ export default Vue.extend({
 			},
 		},
 
-		content: {
-			immediate: true,
-			async handler() {
-				this.currentContent = await this.getContent()
-			},
-		},
-
 		destination(destination) {
 			this.setDestination(destination)
 		},
@@ -350,6 +342,17 @@ export default Vue.extend({
 	},
 
 	methods: {
+		/**
+		 * Handle clicking a new-menu entry
+		 * @param entry The entry that was clicked
+		 */
+		async onClick(entry: Entry) {
+			entry.handler(
+				this.destination!,
+				await this.getContent().catch(() => []),
+			)
+		},
+
 		/**
 		 * Trigger file picker
 		 * @param uploadFolders Upload folders
@@ -408,7 +411,7 @@ export default Vue.extend({
 
 		async handleConflicts(nodes: Array<File|Directory>, path: string): Promise<Array<File|Directory>|false> {
 			try {
-				const content = path === '' ? this.currentContent : await this.getContent(path).catch(() => [])
+				const content = await this.getContent(path).catch(() => [])
 				const conflicts = getConflicts(nodes, content)
 
 				// First handle conflicts as this might already remove invalid files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,30 +1554,16 @@
       }
     },
     "node_modules/@nextcloud/browser-storage": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.3.0.tgz",
-      "integrity": "sha512-vqc26T4WQ3y9EbFpHh4dl/FN7ahEfEoc0unQmsdJ2YSZNTxTvAXAasWI6HFNcHi10b5rEYxxEYjAwKF34th3Aw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
+      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
       "peer": true,
       "dependencies": {
-        "core-js": "3.33.0"
+        "core-js": "3.37.0"
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/calendar-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
-      "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
-      "peer": true,
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
-      },
-      "peerDependencies": {
-        "ical.js": "^1.5.0",
-        "uuid": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/capabilities": {
@@ -1621,89 +1607,6 @@
       "peerDependencies": {
         "@nextcloud/vue": "^8.9.1",
         "vue": "^2.7.16"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/core": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.0.tgz",
-      "integrity": "sha512-x3sD4Mkm7PJ+pcq3HX8PLPBadXCAlSDR/waK87dz0gQE+qJnaaFhc/dZVfJz+IUYzTMVGum2QlR7ImiJQN4s6g==",
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.11.0",
-        "@vueuse/shared": "10.11.0",
-        "vue-demi": ">=0.14.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/metadata": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.0.tgz",
-      "integrity": "sha512-kQX7l6l8dVWNqlqyN3ePW3KmjCQO3ZMgXuBMddIu83CmucrsBfXlH+JoviYyRBws/yLTQO8g3Pbw+bdIoVm4oQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/shared": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
-      "integrity": "sha512-fyNoIXEq3PfX1L3NkNhtVQUSRtqYwJtJg+Bp9rIzculIZWHTkKSysujrOk2J+NrRulLTQH9+3gGSfYLWSEWU1A==",
-      "dependencies": {
-        "vue-demi": ">=0.14.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nextcloud/eslint-config": {
@@ -1896,6 +1799,19 @@
         "npm": "^10.0.0"
       }
     },
+    "node_modules/@nextcloud/timezones": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.1.1.tgz",
+      "integrity": "sha512-ldLuLyz605sszetnp6jy6mtlThu4ICKsZThxHIZwn6t4QzjQH3xr+k8mRU7GIvKq9egUFDqBp4gBjxm3/ROZig==",
+      "peer": true,
+      "dependencies": {
+        "ical.js": "^2.0.1"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/@nextcloud/typings": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.0.tgz",
@@ -1937,28 +1853,29 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
-      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.15.1.tgz",
+      "integrity": "sha512-gZEcXPNhRGYhjSd/IeTs0jQ5P8tPIv9BJm5A8qsdpB1Mb/Xb9suhJv1xHaeGcOGoUCcs7A66coPkCgv1zcSJ2w==",
       "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
-        "@nextcloud/browser-storage": "^0.3.0",
-        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
-        "@nextcloud/l10n": "^2.2.0",
-        "@nextcloud/logger": "^2.7.0",
+        "@nextcloud/l10n": "^3.0.1",
+        "@nextcloud/logger": "^3.0.1",
         "@nextcloud/router": "^3.0.0",
+        "@nextcloud/sharing": "^0.2.2",
+        "@nextcloud/timezones": "^0.1.1",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
         "@vueuse/core": "^10.9.0",
         "clone": "^2.1.2",
-        "debounce": "2.0.0",
+        "debounce": "2.1.0",
         "dompurify": "^3.0.5",
         "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
@@ -1982,11 +1899,12 @@
         "vue": "^2.7.16",
         "vue-color": "^2.8.1",
         "vue-frag": "^1.4.3",
+        "vue-router": "^3.6.5",
         "vue2-datepicker": "^3.11.0"
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/vue-select": {
@@ -1999,51 +1917,6 @@
       },
       "peerDependencies": {
         "vue": "2.x"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-2.2.0.tgz",
-      "integrity": "sha512-UAM2NJcl/NR46MANSF7Gr7q8/Up672zRyGrxLpN3k4URNmWQM9upkbRME+1K3T29wPrUyOIbQu710ZjvZafqFA==",
-      "peer": true,
-      "dependencies": {
-        "@nextcloud/router": "^2.1.2",
-        "@nextcloud/typings": "^1.7.0",
-        "dompurify": "^3.0.3",
-        "escape-html": "^1.0.3",
-        "node-gettext": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n/node_modules/@nextcloud/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-M4AVGnB5tt3MYO5RpH/R2jq7z/nW05AmRhk4Lh68krVwRIYGo8pgNikKrPGogHd2Q3UgzF5Py1drHz3uuV99bQ==",
-      "peer": true,
-      "dependencies": {
-        "@nextcloud/typings": "^1.7.0",
-        "core-js": "^3.6.4"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-DSJg9H1jT2zfr7uoP4tL5hKncyY+LOuxJzLauj0M/f6gnpoXU5WG1Zw8EFPOrRWjkC0ZE+NCqrMnITgdRRpXJQ==",
-      "peer": true,
-      "dependencies": {
-        "@nextcloud/auth": "^2.0.0",
-        "core-js": "^3.6.4"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@types/unist": {
@@ -3271,20 +3144,20 @@
       "dev": true
     },
     "node_modules/@vueuse/components": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-10.9.0.tgz",
-      "integrity": "sha512-BHQpA0yIi3y7zKa1gYD0FUzLLkcRTqVhP8smnvsCK6GFpd94Nziq1XVPD7YpFeho0k5BzbBiNZF7V/DpkJ967A==",
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-10.11.0.tgz",
+      "integrity": "sha512-ZvLZI23d5ZAtva5fGyYh/jQtZO8l+zJ5tAXyYNqHJZkq1o5yWyqZhENvSv5mfDmN5IuAOp4tq02mRmX/ipFGcg==",
       "peer": true,
       "dependencies": {
-        "@vueuse/core": "10.9.0",
-        "@vueuse/shared": "10.9.0",
-        "vue-demi": ">=0.14.7"
+        "@vueuse/core": "10.11.0",
+        "@vueuse/shared": "10.11.0",
+        "vue-demi": ">=0.14.8"
       }
     },
     "node_modules/@vueuse/components/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
       "peer": true,
       "bin": {
@@ -3308,26 +3181,24 @@
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.9.0.tgz",
-      "integrity": "sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==",
-      "peer": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.0.tgz",
+      "integrity": "sha512-x3sD4Mkm7PJ+pcq3HX8PLPBadXCAlSDR/waK87dz0gQE+qJnaaFhc/dZVfJz+IUYzTMVGum2QlR7ImiJQN4s6g==",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.9.0",
-        "@vueuse/shared": "10.9.0",
-        "vue-demi": ">=0.14.7"
+        "@vueuse/metadata": "10.11.0",
+        "@vueuse/shared": "10.11.0",
+        "vue-demi": ">=0.14.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
         "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -3349,32 +3220,29 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.9.0.tgz",
-      "integrity": "sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==",
-      "peer": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.0.tgz",
+      "integrity": "sha512-kQX7l6l8dVWNqlqyN3ePW3KmjCQO3ZMgXuBMddIu83CmucrsBfXlH+JoviYyRBws/yLTQO8g3Pbw+bdIoVm4oQ==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.9.0.tgz",
-      "integrity": "sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==",
-      "peer": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
+      "integrity": "sha512-fyNoIXEq3PfX1L3NkNhtVQUSRtqYwJtJg+Bp9rIzculIZWHTkKSysujrOk2J+NrRulLTQH9+3gGSfYLWSEWU1A==",
       "dependencies": {
-        "vue-demi": ">=0.14.7"
+        "vue-demi": ">=0.14.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
         "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -4545,9 +4413,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
-      "integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
       "hasInstallScript": true,
       "peer": true,
       "funding": {
@@ -4992,9 +4860,9 @@
       "dev": true
     },
     "node_modules/debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
-      "integrity": "sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.1.0.tgz",
+      "integrity": "sha512-OkL3+0pPWCqoBc/nhO9u6TIQNTK44fnBnzuVtJAbp13Naxw9R6u21x+8tVTka87AhDZ3htqZ2pSSsZl9fqL2Wg==",
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -7271,9 +7139,9 @@
       }
     },
     "node_modules/ical.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.5.0.tgz",
-      "integrity": "sha512-7ZxMkogUkkaCx810yp0ZGKvq1ZpRgJeornPttpoxe6nYZ3NLesZe1wWMXDdwTkj/b5NtXT+Y16Aakph/ao98ZQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
+      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw==",
       "peer": true
     },
     "node_modules/iconv-lite": {
@@ -12671,19 +12539,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/validator": {
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
@@ -13611,6 +13466,12 @@
       "peerDependencies": {
         "vue": "^2.6.0"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
+      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==",
+      "peer": true
     },
     "node_modules/vue-template-compiler": {
       "version": "2.7.16",


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/46875

We need to make sure we work with an up-to-date version of the current content, e.g. if a file was removed or added, so reload the current content on click.

The using app (esp. files) should have cached version so no requests are needed. (for files this is already the case).

When releasing this update and merging in server I will provide a cached "getContent" function (load from store if already known) to mitigate performance issues.
**edit** here it is: https://github.com/nextcloud/server/pull/46966