### PR TITLE
chore: Prepare v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 -->
 # Changelog
 
+## [v1.5.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.5.0) \(2024-08-16\)
+### Added
+* feat(UploadPicker): Use `@nextcloud/files` filename validation by default [\#1310](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1310) \([susnux](https://github.com/susnux)\)
+
+### Fixed
+* fix(uploader): Make sure every request is added to the job queue [\#1326](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1326) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* Updated translations
+* chore: Bump @nextcloud/auth to 2.4.0
+* chore: Bump @nextcloud/files to 3.8.0
+* chore: Bump axios to 1.7.4
+
 ## [v1.4.3](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.4.3) \(2024-08-07\)
 ### Fixed
 * fix: Always request current content when triggering a menu entry by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1313

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/upload",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Nextcloud file upload client",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v1.5.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.5.0) \(2024-08-16\)
### Added
* feat(UploadPicker): Use `@nextcloud/files` filename validation by default [\#1310](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1310) \([susnux](https://github.com/susnux)\)

### Fixed
* fix(uploader): Make sure every request is added to the job queue [\#1326](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1326) \([susnux](https://github.com/susnux)\)

### Changed
* Updated translations
* chore: Bump @nextcloud/auth to 2.4.0
* chore: Bump @nextcloud/files to 3.8.0
* chore: Bump axios to 1.7.4