### PR TITLE
fix(uploader): validation of the destination should not compare the class

### DIFF
--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -7,7 +7,7 @@ import type { WebDAVClient } from 'webdav'
 import type { IDirectory } from './utils/fileTree'
 
 import { getCurrentUser } from '@nextcloud/auth'
-import { Folder, Permission, davGetClient, davRemoteURL, davRootPath } from '@nextcloud/files'
+import { FileType, Folder, Permission, davGetClient, davRemoteURL, davRootPath } from '@nextcloud/files'
 import { encodePath } from '@nextcloud/paths'
 import { normalize } from 'path'
 
@@ -107,7 +107,7 @@ export class Uploader {
 	 * Set the upload destination path relative to the root folder
 	 */
 	set destination(folder: Folder) {
-		if (!folder || !(folder instanceof Folder)) {
+		if (!folder || folder.type !== FileType.Folder || !folder.source) {
 			throw new Error('Invalid destination folder')
 		}
 


### PR DESCRIPTION
This some how breaks when used with Vue 2, maybe the prototype is not set correctly, but with the current files app this breaks.
So instead just validate the type if folder and a source is set (we only use the source).