### PR TITLE
test: Cleanup test setup

### DIFF
--- a/__mocks__/@nextcloud/auth.js
+++ b/__mocks__/@nextcloud/auth.js
@@ -9,3 +9,12 @@ export const getCurrentUser = function() {
 		isAdmin: false,
 	}
 }
+
+/** Mock the request token */
+export function getRequestToken() {
+	return 'request-token'
+}
+
+/** Mock that receives a parameter (callback) */
+export function onRequestTokenUpdate() {
+}

--- a/__mocks__/@nextcloud/router.js
+++ b/__mocks__/@nextcloud/router.js
@@ -1,7 +1,8 @@
-/**
+/*!
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 export const generateRemoteUrl = (path) => {
 	return `https://cloud.domain.com/remote.php/${path}`
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { UserConfig } from 'vitest'
+import type { UserConfig } from 'vitest/node'
 import config from './vite.config.ts'
 
 export default async (env) => {
@@ -12,6 +12,11 @@ export default async (env) => {
 
 	cfg.test = {
 		environment: 'jsdom',
+		environmentOptions: {
+			jsdom: {
+				url: 'https://cloud.example.com/index.php/apps/test',
+			},
+		},
 		setupFiles: '__tests__/setup.ts',
 		coverage: {
 			include: ['lib/**'],
@@ -19,11 +24,7 @@ export default async (env) => {
 			exclude: ['lib/utils/l10n.ts'],
 			reporter: ['lcov', 'text'],
 		},
-		server: {
-			deps: {
-				inline: ['@nextcloud/files'],
-			},
-		},
+		pool: 'vmForks',
 	} as UserConfig
 	return cfg
 }


### PR DESCRIPTION
Setup some global location within the setup, also use vmForks so CSS files are correctly mocked during tests. This allows to not inline nextcloud files so we can properly mock it if needed (e.g. for public share tests).