### PR TITLE
fix(uploader): only monitor the queue being idle when we kow we are finishing the upload

### DIFF
--- a/lib/utils/upload.ts
+++ b/lib/utils/upload.ts
@@ -8,6 +8,8 @@ import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
 import axiosRetry, { exponentialDelay } from 'axios-retry'
 
+import logger from './logger'
+
 axiosRetry(axios, { retries: 0 })
 
 type UploadData = Blob | (() => Promise<Blob>)
@@ -101,6 +103,8 @@ export const initChunkWorkspace = async function(destinationFile: string | undef
 			retryDelay: (retryCount, error) => exponentialDelay(retryCount, error, 1000),
 		},
 	})
+
+	logger.debug('Created temporary upload workspace', { url })
 
 	return url
 }


### PR DESCRIPTION
Regression from https://github.com/nextcloud-libraries/nextcloud-upload/pull/1175
Fix for https://github.com/nextcloud/server/issues/49287

## Symptoms
- When uploading with the upload method (not batchUpload), the jobQueue gets idle before the chunks gets computed and between the chunk upload and the final assembly.
- Unfortunately, resetting clear the entirety of the uploadQueue
- This makes the UI looks like there is no pending upload despite more requests being added to the stack afterwards

This is a fix, but we could definitely improve here again, with the batchUpload method, things got messy.
But this would be technical debt, and the bug that this PR fixes is critical.

## Explanations
By moving the idle listener to the end of the method, we are ensuring that the upload's job queue is fully populated before the reset can be triggered.

The original placement in the constructor meant the reset could happen before the upload was fully set up, causing the premature queue clearing we were experiencing. By moving it to the end of the upload method, we are guaranteeing that the queue is fully initialized before any potential reset can occur.
This is a great example of how event listener placement can critically impact the behavior of asynchronous operations