### PR TITLE
1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 -->
 # Changelog
 
+## [v1.7.1](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.7.1) \(2024-12-10\)
+### Fixed
+* fix(uploader): only monitor the queue being idle when we know we are finishing the upload by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1521
+
+### Changed
+* chore(deps): Bump @nextcloud/files from 3.9.1 to 3.10.0 by @dependabot
+* chore(deps): Bump @nextcloud/sharing from 0.2.3 to 0.2.4 by @dependabot
+* chore(deps): Bump axios from 1.7.7 to 1.7.9 by @dependabot
+* Translations updates
+
+**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.7.0...v1.7.1
+
 ## [v1.7.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.7.0) \(2024-11-13\)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/upload",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Nextcloud file upload client",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v1.7.1](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.7.1) \(2024-12-10\)
### Fixed
* fix(uploader): only monitor the queue being idle when we know we are finishing the upload by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1521

### Changed
* chore(deps): Bump @nextcloud/files from 3.9.1 to 3.10.0 by @dependabot
* chore(deps): Bump @nextcloud/sharing from 0.2.3 to 0.2.4 by @dependabot
* chore(deps): Bump axios from 1.7.7 to 1.7.9 by @dependabot
* Translations updates

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.7.0...v1.7.1