### PR TITLE
feat: add assembling status to UploadPicker

### DIFF
--- a/cypress/components/UploadPicker/UploadPicker.cy.ts
+++ b/cypress/components/UploadPicker/UploadPicker.cy.ts
@@ -138,9 +138,6 @@ describe('UploadPicker valid uploads', () => {
 	afterEach(() => resetDocument())
 
 	it('Uploads a file with chunking', () => {
-		// Init and reset chunk request spy
-		const chunksRequestsSpy = cy.spy()
-
 		// Intercept tmp upload chunks folder creation
 		cy.intercept('MKCOL', '/remote.php/dav/uploads/*/web-file-upload*', {
 			statusCode: 201,
@@ -151,7 +148,6 @@ describe('UploadPicker valid uploads', () => {
 			method: 'PUT',
 			url: '/remote.php/dav/uploads/*/web-file-upload*/*',
 		}, (req) => {
-			chunksRequestsSpy()
 			req.reply({
 				statusCode: 201,
 			})
@@ -193,7 +189,7 @@ describe('UploadPicker valid uploads', () => {
 			cy.get('[data-cy-upload-picker] .upload-picker__progress')
 				.as('progress')
 				.should('not.be.visible')
-			expect(chunksRequestsSpy).to.have.always.been.callCount(26)
+			cy.get('@chunks.all').should('have.lengthOf', 26)
 		})
 	})
 

--- a/cypress/components/UploadPicker/status.cy.ts
+++ b/cypress/components/UploadPicker/status.cy.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+// dist file might not be built when running eslint only
+// eslint-disable-next-line import/no-unresolved,n/no-missing-import
+import { Folder, Permission } from '@nextcloud/files'
+import { generateRemoteUrl } from '@nextcloud/router'
+import { getUploader, UploadPicker } from '../../../lib/index.ts'
+
+let state: string | undefined
+before(() => {
+	cy.window().then((win) => {
+		state = win.document.body.innerHTML
+	})
+})
+
+const resetDocument = () => {
+	if (state) {
+		cy.window().then((win) => {
+			win.document.body.innerHTML = state!
+		})
+	}
+}
+
+describe('UploadPicker: status testing', () => {
+	beforeEach(() => {
+		// Make sure we reset the destination
+		// so other tests do not interfere
+		const propsData = {
+			destination: new Folder({
+				id: 56,
+				owner: 'user',
+				source: generateRemoteUrl('dav/files/user'),
+				permissions: Permission.ALL,
+				root: '/files/user',
+			}),
+		}
+
+		// Mount picker
+		const onPause = cy.spy().as('pausedListener')
+		const onResume = cy.spy().as('resumedListener')
+		cy.mount(UploadPicker, {
+			propsData,
+			listeners: {
+				paused: onPause,
+				resumed: onResume,
+			},
+		}).as('uploadPicker')
+
+		// Check and init aliases
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
+		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
+	})
+
+	afterEach(() => resetDocument())
+
+	it('shows paused status on pause', () => {
+		// Intercept tmp upload chunks folder creation
+		cy.intercept('MKCOL', '/remote.php/dav/uploads/*/web-file-upload*', {
+			statusCode: 201,
+		}).as('init')
+
+		// Intercept chunks upload
+		cy.intercept({
+			method: 'PUT',
+			url: '/remote.php/dav/uploads/*/web-file-upload*/*',
+		}, (req) => {
+			req.reply({
+				statusCode: 201,
+			})
+		}).as('chunks')
+
+		// Intercept final assembly request
+		const assemblyStartStub = cy.stub().as('assemblyStart')
+		cy.intercept('MOVE', '/remote.php/dav/uploads/*/web-file-upload*/.file', (req) => {
+			assemblyStartStub()
+			req.reply({
+				statusCode: 204,
+				// Fake assembling chunks
+				delay: 5000,
+			})
+		}).as('assemblyEnd')
+
+		// Start upload
+		cy.get('@input').attachFile({
+			// Fake file of 256MB
+			fileContent: new Blob([new ArrayBuffer(256 * 1024 * 1024)]),
+			fileName: 'photos.zip',
+			mimeType: 'application/zip',
+			encoding: 'utf8',
+			lastModified: new Date().getTime(),
+		})
+
+		cy.wait('@init').then(() => {
+			cy.get('[data-cy-upload-picker] .upload-picker__progress')
+				.as('progress')
+				.should('be.visible')
+		})
+
+		cy.wait('@chunks').then(() => {
+			cy.get('[data-cy-upload-picker] .upload-picker__progress')
+				.as('progress')
+				.should('be.visible')
+			cy.get('@progress')
+				.children('progress')
+				.should('not.have.value', '0')
+			cy.get('[data-cy-upload-picker-progress-label]').should('not.contain', 'estimating time left')
+			cy.get('[data-cy-upload-picker-progress-label]').should('not.contain', 'paused')
+
+			cy.wait(1000).then(() => {
+				getUploader().pause()
+			})
+
+			cy.get('[data-cy-upload-picker-progress-label]').should('contain', 'paused')
+			cy.get('@pausedListener').should('have.been.calledOnce')
+
+			cy.wait(1000).then(() => {
+				getUploader().start()
+			})
+
+			cy.get('[data-cy-upload-picker-progress-label]').should('not.contain', 'paused')
+			cy.get('@resumedListener').should('have.been.calledOnce')
+		})
+
+		// Should will retry until success or timeout
+		cy.get('@assemblyStart', { timeout: 30000 }).should('have.been.calledOnce').then(() => {
+			cy.get('[data-cy-upload-picker] .upload-picker__progress')
+				.as('progress')
+				.should('be.visible')
+
+			cy.get('[data-cy-upload-picker-progress-label]').should('not.contain', 'paused')
+			cy.get('[data-cy-upload-picker-progress-label]').should('contain', 'assembling')
+		})
+
+		cy.wait('@assemblyEnd', { timeout: 60000 }).then(() => {
+			cy.get('[data-cy-upload-picker] .upload-picker__progress')
+				.as('progress')
+				.should('not.be.visible')
+		})
+	})
+})

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -29,6 +29,8 @@ import { mount } from '@cypress/vue2'
 
 // @ts-expect-error Mock window so this is an internal property
 window._oc_capabilities = { files: {} }
+// @ts-expect-error Mock window so this is an internal property
+window._oc_debug = true
 
 // Example use:
 // cy.mount(MyComponent)

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -22,13 +22,18 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "{seconds} seconds left"
-msgstr ""
+msgid_plural "{seconds} seconds left"
+msgstr[0] ""
+msgstr[1] ""
 
 #. TRANSLATORS time has the format 00:00:00
 msgid "{time} left"
 msgstr ""
 
 msgid "a few seconds left"
+msgstr ""
+
+msgid "assembling"
 msgstr ""
 
 msgid "Cancel"

--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -175,6 +175,8 @@ export class Uploader {
 	public pause() {
 		this._jobQueue.pause()
 		this._queueStatus = Status.PAUSED
+		this.updateStats()
+		logger.debug('Upload paused')
 	}
 
 	/**
@@ -184,6 +186,7 @@ export class Uploader {
 		this._jobQueue.start()
 		this._queueStatus = Status.UPLOADING
 		this.updateStats()
+		logger.debug('Upload resumed')
 	}
 
 	/**
@@ -547,6 +550,8 @@ export class Uploader {
 					await Promise.all(chunksQueue)
 					this.updateStats()
 
+					// Assemble the chunks
+					upload.status = UploadStatus.ASSEMBLING
 					upload.response = await axios.request({
 						method: 'MOVE',
 						url: `${tempUrl}/.file`,

--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -545,46 +545,51 @@ export class Uploader {
 					chunksQueue.push(this._jobQueue.add(request))
 				}
 
-				try {
-					// Once all chunks are sent, assemble the final file
-					await Promise.all(chunksQueue)
-					this.updateStats()
+				const request = async () => {
+					try {
+						// Once all chunks are sent, assemble the final file
+						await Promise.all(chunksQueue)
 
-					// Assemble the chunks
-					upload.status = UploadStatus.ASSEMBLING
-					upload.response = await axios.request({
-						method: 'MOVE',
-						url: `${tempUrl}/.file`,
-						headers: {
-							...this._customHeaders,
-							'X-OC-Mtime': Math.floor(file.lastModified / 1000),
-							'OC-Total-Length': file.size,
-							Destination: encodedDestinationFile,
-						},
-					})
+						// Assemble the chunks
+						upload.status = UploadStatus.ASSEMBLING
+						this.updateStats()
 
-					this.updateStats()
-					upload.status = UploadStatus.FINISHED
-					logger.debug(`Successfully uploaded ${file.name}`, { file, upload })
-					resolve(upload)
-				} catch (error) {
-					if (isCancel(error) || error instanceof UploadCancelledError) {
-						upload.status = UploadStatus.CANCELLED
-						reject(new UploadCancelledError(error))
-					} else {
-						upload.status = UploadStatus.FAILED
-						reject(t('Failed assembling the chunks together'))
+						// Send the assemble request
+						upload.response = await axios.request({
+							method: 'MOVE',
+							url: `${tempUrl}/.file`,
+							headers: {
+								...this._customHeaders,
+								'X-OC-Mtime': Math.floor(file.lastModified / 1000),
+								'OC-Total-Length': file.size,
+								Destination: encodedDestinationFile,
+							},
+						})
+						upload.status = UploadStatus.FINISHED
+						this.updateStats()
+
+						logger.debug(`Successfully uploaded ${file.name}`, { file, upload })
+						resolve(upload)
+					} catch (error) {
+						if (isCancel(error) || error instanceof UploadCancelledError) {
+							upload.status = UploadStatus.CANCELLED
+							reject(new UploadCancelledError(error))
+						} else {
+							upload.status = UploadStatus.FAILED
+							reject(t('Failed assembling the chunks together'))
+						}
+						// Cleaning up temp directory
+						axios.request({
+							method: 'DELETE',
+							url: `${tempUrl}`,
+						})
+					} finally {
+						// Notify listeners of the upload completion
+						this._notifyAll(upload)
 					}
-
-					// Cleaning up temp directory
-					axios.request({
-						method: 'DELETE',
-						url: `${tempUrl}`,
-					})
 				}
 
-				// Notify listeners of the upload completion
-				this._notifyAll(upload)
+				this._jobQueue.add(request)
 			} else {
 				logger.debug('Initializing regular upload', { file, upload })
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/51304d16-a757-46b1-998d-f98064563cac)


@Koc here is my take on this.
I think adding some text to the right isn't the right approach.
Now we make sure we don't have any ongoing upload that are NOT assembling
If all is left is assembling tasks, we show the status.

- [x] Assembling status uploader fix
- [x] Assembling status vue component feat
- [x] Cypress tests

Closes https://github.com/nextcloud-libraries/nextcloud-upload/pull/1458