### PR TITLE
fix(NodesPicker): Use preview fit cover

### DIFF
--- a/lib/components/NodesPicker.vue
+++ b/lib/components/NodesPicker.vue
@@ -334,8 +334,7 @@ $height: 64px;
 	&__preview {
 		overflow: hidden;
 		border-radius: calc(var(--border-radius) * 2);
-		background-position: center;
-		background-size: cover;
+		object-fit: cover;
 	}
 
 	&__desc {


### PR DESCRIPTION
The server generates the preview using cover mode, so the local preview of the new file should do the same.
Also the preview was always distorted, I believe this was due to background-size not applying to the image.
To fix this I had to use object-fit instead.

Before:
![image](https://github.com/user-attachments/assets/e3d6587b-5fa9-4cf1-8954-a07c945f2b11)

After:
![image](https://github.com/user-attachments/assets/0fdc36ca-6328-4549-a93c-59b5d285f93c)
