### PR TITLE
test: adjust config for vitest v3 and await expect

### DIFF
--- a/__tests__/uploader.spec.ts
+++ b/__tests__/uploader.spec.ts
@@ -46,7 +46,7 @@ describe('Uploader', () => {
 
 		it('fails if not logged in and not on public share', async () => {
 			vi.spyOn(nextcloudAuth, 'getCurrentUser').mockImplementationOnce(() => null)
-			expect(async () => new Uploader()).rejects.toThrow(/User is not logged in/)
+			await expect(async () => new Uploader()).rejects.toThrow(/User is not logged in/)
 		})
 	})
 
@@ -119,7 +119,7 @@ describe('Uploader', () => {
 				mime: 'text/plain',
 			})
 
-			expect(() => { uploader.destination = newDestination as nextcloudFiles.Folder }).toThrowError(/invalid destination/i)
+			expect(() => { uploader.destination = newDestination as unknown as nextcloudFiles.Folder }).toThrowError(/invalid destination/i)
 		})
 	})
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,25 +6,23 @@ import type { UserConfig } from 'vitest/node'
 import config from './vite.config.ts'
 
 export default async (env) => {
-	const cfg = await config(env)
-	// Node externals does not work with vitest
-	cfg.plugins = cfg.plugins!.filter((plugin) => plugin && 'name' in plugin && plugin.name !== 'node-externals')
-
-	cfg.test = {
-		environment: 'jsdom',
-		environmentOptions: {
-			jsdom: {
-				url: 'https://cloud.example.com/index.php/apps/test',
+	return {
+		...await config(env),
+		test: {
+			environment: 'jsdom',
+			environmentOptions: {
+				jsdom: {
+					url: 'https://cloud.example.com/index.php/apps/test',
+				},
 			},
-		},
-		setupFiles: '__tests__/setup.ts',
-		coverage: {
-			include: ['lib/**'],
-			// This makes no sense to test
-			exclude: ['lib/utils/l10n.ts'],
-			reporter: ['lcov', 'text'],
-		},
-		pool: 'vmForks',
-	} as UserConfig
-	return cfg
+			setupFiles: '__tests__/setup.ts',
+			coverage: {
+				include: ['lib/**'],
+				// This makes no sense to test
+				exclude: ['lib/utils/l10n.ts'],
+				reporter: ['lcov', 'text'],
+			},
+			pool: 'vmForks',
+		} as UserConfig,
+	}
 }


### PR DESCRIPTION
We can simplify the vitest config a bit as some things are fixed.
Also this fixes a test as `expect.rejects.toThrow` is an asynchronous expectation so we need to await it.