### PR TITLE
chore: include vue devtools in dev build

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -28,3 +28,9 @@ path = ["cypress/fixtures/image.jpg"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2016 pixabay <https://www.pexels.com/@pixabay/> <https://www.pexels.com/photo/gray-and-brown-mountain-417173/>"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = [".env.development"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2025 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "CC0-1.0"


### PR DESCRIPTION
Vue devtools will be removed / disabled if `NODE_ENV=production` which is the default.
To enable it we need to explicitly set it (vite mode and `NODE_ENV` are two distinct things).