### PR TITLE
fix(uploader): upload cancellation status

### DIFF
--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -306,7 +306,8 @@ export default defineComponent({
 			return this.queue?.filter((upload: Upload) => upload.status === UploadStatus.FAILED).length !== 0
 		},
 		isUploading(): boolean {
-			return this.queue?.length > 0
+			// also ignore cancelled uploads
+			return this.queue?.filter((upload: Upload) => upload.status !== UploadStatus.CANCELLED).length > 0
 		},
 		isAssembling(): boolean {
 			return this.queue?.filter((upload: Upload) => upload.status === UploadStatus.ASSEMBLING).length !== 0

--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -295,7 +295,7 @@ export class Uploader {
 				resolve(uploads)
 			} catch (error) {
 				logger.error('Error in batch upload', { error })
-				upload.status = UploadStatus.FAILED
+				upload.status = UploadStatus.CANCELLED
 				reject(t('Upload has been cancelled'))
 			} finally {
 				this._notifyAll(upload)
@@ -556,7 +556,7 @@ export class Uploader {
 						upload.status = UploadStatus.FAILED
 						reject('Failed assembling the chunks together')
 					} else {
-						upload.status = UploadStatus.FAILED
+						upload.status = UploadStatus.CANCELLED
 						reject(t('Upload has been cancelled'))
 					}
 
@@ -608,7 +608,7 @@ export class Uploader {
 						resolve(upload)
 					} catch (error) {
 						if (isCancel(error)) {
-							upload.status = UploadStatus.FAILED
+							upload.status = UploadStatus.CANCELLED
 							reject(t('Upload has been cancelled'))
 							return
 						}


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-upload/issues/1543

To reproduce:
1. Upload a file which already exists
2. Cancel
3. See the progress still visible
4. See error saying something went wrong (but it didn't, the user cancelled on purpose)