### PR TITLE
feat(uploader): add ETA implementation with upload speed information

### DIFF
--- a/cypress/components/UploadPicker/UploadPicker.cy.ts
+++ b/cypress/components/UploadPicker/UploadPicker.cy.ts
@@ -3,9 +3,7 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-// dist file might not be built when running eslint only
-// eslint-disable-next-line import/no-unresolved,n/no-missing-import
-import { Folder, Permission, addNewFileMenuEntry, type Entry } from '@nextcloud/files'
+import { Folder, Permission } from '@nextcloud/files'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { UploadPicker, UploadStatus, getUploader } from '../../../lib/index.ts'
 
@@ -39,8 +37,9 @@ describe('UploadPicker rendering', () => {
 		}
 		cy.mount(UploadPicker, { propsData })
 		cy.get('[data-cy-upload-picker]').should('be.visible')
-		cy.get('[data-cy-upload-picker]').shouldHaveTrimmedText('New')
+		cy.get('[data-cy-upload-picker]').should('contain.text', 'New')
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').should('exist')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-progress]').should('not.be.visible')
 	})
 
 	it('Does NOT render without a destination', () => {
@@ -68,22 +67,22 @@ describe('UploadPicker valid uploads', () => {
 		cy.mount(UploadPicker, { propsData }).as('uploadPicker')
 
 		// Label is displayed before upload
-		cy.get('[data-cy-upload-picker]').shouldHaveTrimmedText('New')
+		cy.get('[data-cy-upload-picker]')
+			.contains('button', 'New')
+			.should('be.visible')
 
 		// Check and init aliases
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
-		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-progress]').as('progress').should('exist')
 	})
 
 	afterEach(() => resetDocument())
 
 	it('Uploads a file', () => {
-		// Intercept single upload
+		const { promise, resolve } = Promise.withResolvers<void>()
 		cy.intercept('PUT', '/remote.php/dav/files/*/*', (req) => {
-			req.reply({
-				statusCode: 201,
-				delay: 2000,
-			})
+			req.reply({ statusCode: 201 })
+			req.on('response', async () => await promise)
 		}).as('upload')
 
 		cy.get('@input').attachFile({
@@ -95,16 +94,20 @@ describe('UploadPicker valid uploads', () => {
 			lastModified: new Date().getTime(),
 		})
 
-		cy.get('[data-cy-upload-picker] .upload-picker__progress')
-			.as('progress')
-			.should('be.visible')
-
-		// Label gets hidden during upload
-		cy.get('[data-cy-upload-picker]').should('not.have.text', 'New')
+		cy.get('@progress').should('be.visible')
+		cy.get('[data-cy-upload-picker]')
+			.within(() => {
+				// Label gets hidden during upload
+				cy.contains('button', 'New').should('not.exist')
+				// but the button exists
+				cy.get('button[data-cy-upload-picker-add]')
+					.should('be.visible')
+					.and('have.attr', 'aria-label', 'New')
+			})
+			.then(() => resolve())
 
 		cy.wait('@upload').then(() => {
-			cy.get('[data-cy-upload-picker] .upload-picker__progress')
-				.as('progress')
+			cy.get('@progress')
 				.should('not.be.visible')
 
 			// Label is displayed again after upload

--- a/cypress/components/UploadPicker/UploadPicker.cy.ts
+++ b/cypress/components/UploadPicker/UploadPicker.cy.ts
@@ -111,7 +111,7 @@ describe('UploadPicker valid uploads', () => {
 				.should('not.be.visible')
 
 			// Label is displayed again after upload
-			cy.get('[data-cy-upload-picker] button').shouldHaveTrimmedText('New')
+			cy.get('[data-cy-upload-picker] button').should('contain.text', 'New')
 		})
 	})
 })

--- a/cypress/components/UploadPicker/invalid-filenames.cy.ts
+++ b/cypress/components/UploadPicker/invalid-filenames.cy.ts
@@ -59,7 +59,7 @@ describe('UploadPicker: invalid filenames (legacy prop)', { testIsolation: true 
 		cy.mount(UploadPicker, { propsData }).as('uploadPicker')
 
 		// Label is displayed before upload
-		cy.get('[data-cy-upload-picker]').shouldHaveTrimmedText('New')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-add]').should('contain.text', 'New')
 
 		// Check and init aliases
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
@@ -193,11 +193,11 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 		cy.mount(UploadPicker, { propsData }).as('uploadPicker')
 
 		// Label is displayed before upload
-		cy.get('[data-cy-upload-picker]').shouldHaveTrimmedText('New')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-add]').should('contain.text', 'New')
 
 		// Check and init aliases
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
-		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-progress]').as('progress').should('exist')
 
 		// Upload
 		cy.get('@input').attachFile({
@@ -208,8 +208,7 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 			lastModified: new Date().getTime(),
 		})
 
-		cy.get('[data-cy-upload-picker] .upload-picker__progress')
-			.as('progress')
+		cy.get('@progress')
 			.should('not.be.visible')
 
 		cy.contains('[role="dialog"]', 'Invalid filename')
@@ -234,11 +233,11 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 		cy.mount(UploadPicker, { propsData }).as('uploadPicker')
 
 		// Label is displayed before upload
-		cy.get('[data-cy-upload-picker]').shouldHaveTrimmedText('New')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-add]').should('contain.text', 'New')
 
 		// Check and init aliases
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
-		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-progress]').as('progress').should('exist')
 
 		// Upload
 		cy.get('@input').attachFile({
@@ -249,8 +248,7 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 			lastModified: new Date().getTime(),
 		})
 
-		cy.get('[data-cy-upload-picker] .upload-picker__progress')
-			.as('progress')
+		cy.get('@progress')
 			.should('not.be.visible')
 
 		cy.contains('[role="dialog"]', 'Invalid filename')
@@ -275,11 +273,11 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 		cy.mount(UploadPicker, { propsData }).as('uploadPicker')
 
 		// Label is displayed before upload
-		cy.get('[data-cy-upload-picker]').shouldHaveTrimmedText('New')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-add]').should('contain.text', 'New')
 
 		// Check and init aliases
 		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-input]').as('input').should('exist')
-		cy.get('[data-cy-upload-picker] .upload-picker__progress').as('progress').should('exist')
+		cy.get('[data-cy-upload-picker] [data-cy-upload-picker-progress]').as('progress').should('exist')
 
 		// Upload
 		cy.get('@input').attachFile({
@@ -290,8 +288,7 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 			lastModified: new Date().getTime(),
 		})
 
-		cy.get('[data-cy-upload-picker] .upload-picker__progress')
-			.as('progress')
+		cy.get('@progress')
 			.should('not.be.visible')
 
 		cy.contains('[role="dialog"]', 'Invalid filename')
@@ -390,8 +387,7 @@ describe.only('UploadPicker: invalid filenames (server capabilities)', { testIso
 			lastModified: new Date().getTime(),
 		}])
 
-		cy.get('[data-cy-upload-picker] .upload-picker__progress')
-			.as('progress')
+		cy.get('@progress')
 			.should('not.be.visible')
 
 		cy.contains('[role="dialog"]', 'Invalid filename')

--- a/cypress/components/UploadPicker/progress.cy.ts
+++ b/cypress/components/UploadPicker/progress.cy.ts
@@ -76,8 +76,8 @@ describe('UploadPicker: progress handling', () => {
 
 	it('has upload speed information', () => {
 		cy.get('@input').attachFile({
-			// file of 5 MiB
-			fileContent: new Blob([new ArrayBuffer(5 * 1024 * 1024)]),
+			// file of 9 MiB
+			fileContent: new Blob([new ArrayBuffer(9 * 1024 * 1024)]),
 			fileName: 'file.txt',
 			mimeType: 'text/plain',
 			encoding: 'utf8',
@@ -86,8 +86,8 @@ describe('UploadPicker: progress handling', () => {
 
 		cy.intercept('PUT', '/remote.php/dav/files/user/file.txt', { statusCode: 201 })
 
-		// 512 KB/s
-		throttleUpload(512 * 1024)
+		// 128 KB/s
+		throttleUpload(128 * 1024)
 
 		// See there is no progress yet
 		cy.get('@progress')
@@ -101,6 +101,15 @@ describe('UploadPicker: progress handling', () => {
 		// See the upload has started
 		cy.get('@progressLabel', { timeout: 10000 })
 			.should((el) => expect(el.text()).to.match(/\d+(\.\d+)?\s?KB∕s/))
+			// increase speed to 1MiB/s
+			.then(() => throttleUpload(1024 * 1024))
+		cy.get('@progressLabel')
+			.children('span')
+			.first({ timeout: 9000 })
+			.should((el) => {
+				expect(el.text().trim()).to.equal('a few seconds left')
+				expect(el.attr('title')).to.match(/\d+(\.\d+)?\s?KB∕s/)
+			})
 	})
 
 	it('has increasing progress bar during non-chunked upload', () => {

--- a/cypress/cypress.d.ts
+++ b/cypress/cypress.d.ts
@@ -12,9 +12,6 @@ declare global {
 	namespace Cypress {
 		interface Chainable {
 			mount: typeof mount
-			shouldHaveTrimmedText: (
-				text: string
-			) => Chainable<JQuery<HTMLElement>>
 		}
 	}
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -13,12 +13,3 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 import 'cypress-file-upload'
-
-Cypress.Commands.add(
-	'shouldHaveTrimmedText',
-	{ prevSubject: true },
-	(subject: JQuery<HTMLElement>, text: string) => {
-		cy.wrap(subject)
-			.should(element => expect(element.text().trim()).to.equal(text))
-	},
-)

--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -122,9 +122,10 @@
 				<span v-else-if="isOnlyAssembling">
 					{{ t('assembling') }}
 				</span>
-				<span v-else>
+				<span v-else :title="etaTimeAndSpeed()">
 					{{ uploadManager.eta.timeReadable }}
-					<span v-if="uploadManager.eta.speedReadable">
+					<!-- the speed is included in the tooltip / title so we only show it in the text content if there is enough space (not showing "a few seconds left") -->
+					<span v-if="uploadManager.eta.speedReadable && uploadManager.eta.time >= 60">
 						({{ uploadManager.eta.speedReadable }})
 					</span>
 				</span>
@@ -381,6 +382,14 @@ export default defineComponent({
 	},
 
 	methods: {
+		etaTimeAndSpeed(): string {
+			const speed = this.uploadManager.eta.speedReadable
+			if (speed) {
+				return `${this.uploadManager.eta.timeReadable} (${speed})`
+			}
+			return this.uploadManager.eta.timeReadable
+		},
+
 		/**
 		 * Handle clicking a new-menu entry
 		 * @param entry The entry that was clicked

--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -132,7 +132,7 @@
 		</div>
 
 		<!-- Cancel upload button -->
-		<NcButton v-if="isUploading"
+		<NcButton v-if="isUploading && !isOnlyAssembling"
 			class="upload-picker__cancel"
 			type="tertiary"
 			:aria-label="t('Cancel uploads')"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,13 +8,13 @@ import type { AsyncComponent } from 'vue'
 import { isPublicShare } from '@nextcloud/sharing/public'
 import Vue, { defineAsyncComponent } from 'vue'
 
-import { Uploader } from './uploader'
+import { Uploader } from './uploader/uploader'
 import UploadPicker from './components/UploadPicker.vue'
 
 export type { IDirectory, Directory } from './utils/fileTree'
 export { getConflicts, hasConflict, uploadConflictHandler } from './utils/conflicts'
 export { Upload, Status as UploadStatus } from './upload'
-export { Uploader, Status as UploaderStatus } from './uploader'
+export * from './uploader/index.ts'
 
 export type ConflictResolutionResult<T extends File|FileSystemEntry|Node> = {
 	selected: T[],

--- a/lib/uploader/eta.spec.ts
+++ b/lib/uploader/eta.spec.ts
@@ -1,0 +1,278 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { afterAll, beforeAll, describe, expect, it, test, vi } from 'vitest'
+import { Eta, EtaStatus } from './eta.ts'
+
+describe('ETA - status', () => {
+	it('has default set', () => {
+		const eta = new Eta()
+		expect(eta.progress).toBe(0)
+		expect(eta.time).toBe(Infinity)
+		expect(eta.timeReadable).toBe('estimating time left')
+		expect(eta.speed).toBe(-1)
+		expect(eta.status).toBe(EtaStatus.Idle)
+	})
+
+	it('can autostart in constructor', () => {
+		const eta = new Eta({ start: true, total: 100 })
+		expect(eta.status).toBe(EtaStatus.Running)
+		expect(eta.progress).toBe(0)
+		expect(eta.time).toBe(Infinity)
+		expect(eta.timeReadable).toBe('estimating time left')
+		expect(eta.speed).toBe(-1)
+	})
+
+	it('can reset', () => {
+		const eta = new Eta({ start: true, total: 100 })
+		expect(eta.status).toBe(EtaStatus.Running)
+
+		eta.add(10)
+		expect(eta.progress).toBe(10)
+
+		eta.reset()
+		expect(eta.status).toBe(EtaStatus.Idle)
+		expect(eta.progress).toBe(0)
+	})
+
+	it('does not update when idle', () => {
+		const eta = new Eta()
+		expect(eta.progress).toBe(0)
+
+		eta.update(10, 100)
+		expect(eta.progress).toBe(0)
+
+		eta.add(10)
+		expect(eta.progress).toBe(0)
+		expect(eta.status).toBe(EtaStatus.Idle)
+	})
+
+	it('does not update when paused', () => {
+		const eta = new Eta({ start: true, total: 100 })
+		eta.add(10)
+		expect(eta.progress).toBe(10)
+
+		eta.pause()
+		eta.add(10)
+		expect(eta.progress).toBe(10)
+		expect(eta.status).toBe(EtaStatus.Paused)
+	})
+
+	it('can resume', () => {
+		const eta = new Eta()
+		expect(eta.status).toBe(EtaStatus.Idle)
+		eta.resume()
+		expect(eta.status).toBe(EtaStatus.Running)
+	})
+})
+
+describe('ETA - progress', () => {
+	beforeAll(() => vi.useFakeTimers())
+	afterAll(() => vi.useRealTimers())
+
+	test('progress calculation', () => {
+		const eta = new Eta({ start: true, total: 100 * 1024 * 1024, cutoffTime: 2.5 })
+		expect(eta.progress).toBe(0)
+
+		// First upload some parts with about 5MiB/s which should take 3s (total 20s)
+		for (let i = 1; i <= 6; i++) {
+			vi.advanceTimersByTime(500)
+			eta.add(2.5 * 1024 * 1024)
+			expect(eta.progress).toBe(i * 2.5)
+			expect(eta.speed).toBe(-1)
+			expect(eta.speedReadable).toBe('')
+			expect(eta.time).toBe(Infinity)
+		}
+
+		// this is reached after (virtual) 3s with 6 * 2.5MiB (=15MiB) data of 100MiB total
+		expect(eta.timeReadable).toBe('estimating time left')
+
+		// Adding another 500ms with 5MiB/s will result in enough information for estimating
+		vi.advanceTimersByTime(500)
+		eta.add(2.5 * 1024 * 1024)
+		expect(eta.progress).toBe(17.5)
+		expect(eta.speed).toMatchInlineSnapshot('4826778')
+		expect(eta.speedReadable).toMatchInlineSnapshot('"4.6 MB∕s"')
+		expect(eta.time).toMatchInlineSnapshot('18')
+		expect(eta.timeReadable).toMatchInlineSnapshot('"18 seconds left"')
+
+		// Skip forward another 4.5seconds
+		for (let i = 0; i < 9; i++) {
+			vi.advanceTimersByTime(500)
+			eta.add(2.5 * 1024 * 1024)
+		}
+		// See we made some progress
+		expect(eta.progress).toBe(40)
+		// See as we have constant speed, the speed is closing to 5MiB/s (5242880)
+		expect(eta.speed).toMatchInlineSnapshot('5060836')
+		expect(eta.speedReadable).toMatchInlineSnapshot('"4.8 MB∕s"')
+		expect(eta.time).toMatchInlineSnapshot('12')
+		expect(eta.timeReadable).toMatchInlineSnapshot('"12 seconds left"')
+
+		// Having a spike of 10MiB/s will not result in halfing the eta
+		vi.advanceTimersByTime(500)
+		eta.add(5 * 1024 * 1024)
+		expect(eta.progress).toBe(45)
+		// See the value is not doubled
+		expect(eta.speed).toMatchInlineSnapshot('5208613')
+		expect(eta.speedReadable).toMatchInlineSnapshot('"5 MB∕s"')
+		// And the time has not halved
+		expect(eta.time).toMatchInlineSnapshot('11')
+		expect(eta.timeReadable).toMatchInlineSnapshot('"11 seconds left"')
+
+		// Add another 3 seconds so we should see 'few seconds left'
+		for (let i = 0; i < 6; i++) {
+			vi.advanceTimersByTime(500)
+			eta.add(2.5 * 1024 * 1024)
+		}
+		expect(eta.progress).toBe(60)
+		expect(eta.speed).toMatchInlineSnapshot('5344192')
+		expect(eta.time).toMatchInlineSnapshot('8')
+		expect(eta.timeReadable).toMatchInlineSnapshot('"a few seconds left"')
+	})
+
+	test('long running progress', () => {
+		const eta = new Eta({ start: true, total: 100 * 1024 * 1024, cutoffTime: 2.5 })
+		expect(eta.progress).toBe(0)
+
+		// First upload some parts with about 1MiB/s
+		for (let i = 1; i <= 6; i++) {
+			vi.advanceTimersByTime(500)
+			eta.add(512 * 1024)
+			expect(eta.progress).toBe(i / 2)
+			expect(eta.speed).toBe(-1)
+			expect(eta.time).toBe(Infinity)
+		}
+
+		// Now we should be able to see some progress
+		vi.advanceTimersByTime(500)
+		eta.add(512 * 1024)
+		expect(eta.progress).toBe(3.5)
+		expect(eta.time).toBe(105)
+		// time is over 1 minute so we see the formatted output
+		expect(eta.timeReadable).toMatchInlineSnapshot('"00:01:45 left"')
+
+		// Add another minute and we should see only seconds:
+		for (let i = 0; i < 120; i++) {
+			vi.advanceTimersByTime(500)
+			eta.add(512 * 1024)
+			expect(eta.progress).toBe(4 + 0.5 * i)
+		}
+
+		// Now we have uploaded 63.5 MiB - so 36.5 MiB missing by having 1MiB/s upload speed we expect 37 seconds left:
+		expect(eta.progress).toBe(63.5)
+		expect(eta.time).toBe(37)
+		expect(eta.timeReadable).toMatchInlineSnapshot('"37 seconds left"')
+	})
+
+	it('can autostart in constructor', () => {
+		const eta = new Eta({ start: true, total: 100 })
+		expect(eta.status).toBe(EtaStatus.Running)
+		expect(eta.progress).toBe(0)
+		expect(eta.time).toBe(Infinity)
+		expect(eta.timeReadable).toBe('estimating time left')
+		expect(eta.speed).toBe(-1)
+	})
+
+	it('can reset', () => {
+		const eta = new Eta({ start: true, total: 100 })
+		expect(eta.status).toBe(EtaStatus.Running)
+
+		eta.add(10)
+		expect(eta.progress).toBe(10)
+
+		eta.reset()
+		expect(eta.status).toBe(EtaStatus.Idle)
+		expect(eta.progress).toBe(0)
+	})
+
+	it('does not update when idle', () => {
+		const eta = new Eta()
+		expect(eta.progress).toBe(0)
+
+		eta.update(10, 100)
+		expect(eta.progress).toBe(0)
+
+		eta.add(10)
+		expect(eta.progress).toBe(0)
+		expect(eta.status).toBe(EtaStatus.Idle)
+	})
+
+	it('does not update when paused', () => {
+		const eta = new Eta({ start: true, total: 100 })
+		eta.add(10)
+		expect(eta.progress).toBe(10)
+
+		eta.pause()
+		eta.add(10)
+		expect(eta.progress).toBe(10)
+		expect(eta.status).toBe(EtaStatus.Paused)
+	})
+
+	it('can resume', () => {
+		const eta = new Eta()
+		expect(eta.status).toBe(EtaStatus.Idle)
+		eta.resume()
+		expect(eta.status).toBe(EtaStatus.Running)
+	})
+})
+
+describe('ETA - events', () => {
+	it('emits updated event', () => {
+		const spy = vi.fn()
+		const eta = new Eta()
+		eta.addEventListener('update', spy)
+
+		// only works when running so nothing should happen
+		eta.update(10, 100)
+		expect(spy).not.toBeCalled()
+
+		// now start and update
+		eta.resume()
+		eta.update(10, 100)
+		expect(spy).toBeCalledTimes(1)
+	})
+
+	it('emits reset event', () => {
+		const spy = vi.fn()
+		const eta = new Eta()
+		eta.addEventListener('reset', spy)
+
+		eta.reset()
+		expect(spy).toBeCalledTimes(1)
+	})
+
+	it('emits pause event', () => {
+		const spy = vi.fn()
+		const eta = new Eta()
+		eta.addEventListener('pause', spy)
+
+		// cannot pause if not running
+		eta.pause()
+		expect(spy).toBeCalledTimes(0)
+
+		// start
+		eta.resume()
+		expect(spy).toBeCalledTimes(0)
+
+		// Pause - this time the event should be emitted
+		eta.pause()
+		expect(spy).toBeCalledTimes(1)
+		// double pause does nothing
+		eta.pause()
+		expect(spy).toBeCalledTimes(1)
+	})
+
+	it('emits resume event', () => {
+		const spy = vi.fn()
+		const eta = new Eta()
+		eta.addEventListener('resume', spy)
+
+		eta.resume()
+		expect(spy).toBeCalledTimes(1)
+		// already resumed so nothing happens
+		eta.resume()
+		expect(spy).toBeCalledTimes(1)
+	})
+})

--- a/lib/uploader/eta.ts
+++ b/lib/uploader/eta.ts
@@ -1,0 +1,210 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { TypedEventTarget } from 'typescript-event-target'
+import { n, t } from '../utils/l10n.ts'
+import { formatFileSize } from '@nextcloud/files'
+
+export enum EtaStatus {
+	Idle = 0,
+	Paused = 1,
+	Running = 2,
+}
+
+interface EtaOptions {
+	/** Low pass filter cutoff time for smoothing the speed */
+	cutoffTime?: number
+	/** Total number of bytes to be expected */
+	total?: number
+	/** Start the estimation directly */
+	start?: boolean
+}
+
+export interface EtaEventsMap {
+	pause: CustomEvent
+	reset: CustomEvent
+	resume: CustomEvent
+	update: CustomEvent
+}
+
+export class Eta extends TypedEventTarget<EtaEventsMap> {
+
+	/** Bytes done */
+	private _done: number = 0
+	/** Total bytes to do */
+	private _total: number = 0
+	/** Current progress (cached) as interval [0,1] */
+	private _progress: number = 0
+	/** Status of the ETA */
+	private _status: EtaStatus = EtaStatus.Idle
+	/** Time of the last update */
+	private _startTime: number = -1
+	/** Total elapsed time for current ETA */
+	private _elapsedTime: number = 0
+	/** Current speed in bytes per second */
+	private _speed: number = -1
+	/** Expected duration to finish in seconds */
+	private _eta: number = Infinity
+
+	/**
+	 * Cutoff time for the low pass filter of the ETA.
+	 * A higher value will consider more history information for calculation,
+	 * and thus suppress spikes of the speed,
+	 * but will make the overall resposiveness slower.
+	 */
+	private _cutoffTime = 2.5
+
+	public constructor(options: EtaOptions = {}) {
+		super()
+		if (options.start) {
+			this.resume()
+		}
+		if (options.total) {
+			this.update(0, options.total)
+		}
+		this._cutoffTime = options.cutoffTime ?? 2.5
+	}
+
+	/**
+	 * Add more transferred bytes.
+	 * @param done Additional bytes done.
+	 */
+	public add(done: number): void {
+		this.update(this._done + done)
+	}
+
+	/**
+	 * Update the transmission state.
+	 *
+	 * @param done The new value of transferred bytes.
+	 * @param total Optionally also update the total bytes we expect.
+	 */
+	public update(done: number, total?: number): void {
+		if (this.status !== EtaStatus.Running) {
+			return
+		}
+		if (total && total > 0) {
+			this._total = total
+		}
+
+		const deltaDone = done - this._done
+		const deltaTime = (Date.now() - this._startTime) / 1000
+
+		this._startTime = Date.now()
+		this._elapsedTime += deltaTime
+		this._done = done
+		this._progress = this._done / this._total
+
+		// Only update speed when the history is large enough so we can estimate it
+		const historyNeeded = this._cutoffTime + deltaTime
+		if (this._elapsedTime > historyNeeded) {
+			// Filter the done bytes using a low pass filter to suppress speed spikes
+			const alpha = deltaTime / (deltaTime + (1 / this._cutoffTime))
+			const filtered = (this._done - deltaDone) + (1 - alpha) * deltaDone
+			// bytes per second - filtered
+			this._speed = Math.round(filtered / this._elapsedTime)
+		}
+
+		// Update the eta if we have valid speed information (prevent divide by zero)
+		if (this._speed > 0) {
+			// Estimate transfer of remaining bytes with current average speed
+			this._eta = Math.round((this._total - this._done) / this._speed)
+		}
+
+		this.dispatchTypedEvent('update', new CustomEvent('update', { cancelable: false }))
+	}
+
+	public reset(): void {
+		this._done = 0
+		this._total = 0
+		this._progress = 0
+		this._elapsedTime = 0
+		this._eta = Infinity
+		this._speed = -1
+		this._startTime = -1
+		this._status = EtaStatus.Idle
+		this.dispatchTypedEvent('reset', new CustomEvent('reset'))
+	}
+
+	/**
+	 * Pause the ETA calculation.
+	 */
+	public pause(): void {
+		if (this._status === EtaStatus.Running) {
+			this._status = EtaStatus.Paused
+			this._elapsedTime += (Date.now() - this._startTime) / 1000
+			this.dispatchTypedEvent('pause', new CustomEvent('pause'))
+		}
+	}
+
+	/**
+	 * Resume the ETA calculation.
+	 */
+	public resume(): void {
+		if (this._status !== EtaStatus.Running) {
+			this._startTime = Date.now()
+			this._status = EtaStatus.Running
+			this.dispatchTypedEvent('resume', new CustomEvent('resume'))
+		}
+	}
+
+	/**
+	 * Status of the Eta (paused, active, idle).
+	 */
+	public get status(): EtaStatus {
+		return this._status
+	}
+
+	/**
+	 * Progress (percent done)
+	 */
+	public get progress(): number {
+		return Math.round(this._progress * 10000) / 100
+	}
+
+	/**
+	 * Estimated time in seconds.
+	 */
+	public get time(): number {
+		return this._eta
+	}
+
+	/**
+	 * Human readable version of the estimated time.
+	 */
+	public get timeReadable(): string {
+		if (this._eta === Infinity) {
+			return t('estimating time left')
+		} else if (this._eta < 10) {
+			return t('a few seconds left')
+		} else if (this._eta < 60) {
+			return n('{seconds} seconds left', '{seconds} seconds left', this._eta, { seconds: this._eta })
+		}
+
+		const hours = String(Math.floor(this._eta / 3600)).padStart(2, '0')
+		const minutes = String(Math.floor((this._eta % 3600) / 60)).padStart(2, '0')
+		const seconds = String(this._eta % 60).padStart(2, '0')
+		return t('{time} left', { time: `${hours}:${minutes}:${seconds}` }) // TRANSLATORS time has the format 00:00:00
+	}
+
+	/**
+	 * Transfer speed in bytes per second.
+	 * Returns `-1` if not yet estimated.
+	 */
+	public get speed(): number {
+		return this._speed
+	}
+
+	/**
+	 * Get the speed in human readable format using file sizes like 10KB/s.
+	 * Returns the empty string if not yet estimated.
+	 */
+	public get speedReadable(): string {
+		return this._speed > 0
+			? `${formatFileSize(this._speed, true)}∕s`
+			: ''
+	}
+
+}

--- a/lib/uploader/index.ts
+++ b/lib/uploader/index.ts
@@ -1,0 +1,15 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export {
+	type Eta,
+	type EtaEventsMap,
+	EtaStatus,
+} from './eta.ts'
+
+export {
+	Uploader,
+	UploaderStatus,
+} from './uploader.ts'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "crypto-browserify": "^3.12.1",
         "p-cancelable": "^4.0.1",
         "p-queue": "^8.1.0",
-        "simple-eta": "^3.0.2"
+        "typescript-event-target": "^1.1.1"
       },
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
@@ -11901,11 +11901,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-eta": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/simple-eta/-/simple-eta-3.0.2.tgz",
-      "integrity": "sha512-+OmPgi01yHK/bRNQDoehUcV8fqs9nNJkG2DoWCnnLvj0lmowab7BH3v9776BG0y7dGEOLh0F7mfd37k+ht26Yw=="
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12932,7 +12927,8 @@
     "node_modules/typescript-event-target": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
-      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg=="
+      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
+      "license": "MIT"
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "crypto-browserify": "^3.12.1",
     "p-cancelable": "^4.0.1",
     "p-queue": "^8.1.0",
-    "simple-eta": "^3.0.2"
+    "typescript-event-target": "^1.1.1"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",


### PR DESCRIPTION
* Resolves #1605 
* Party for #816 

This feature implements the following:
- Implement the ETA class our self
- Provide upload speed information in the ETA class
- Move the ETA information to the uploader class
- Remove custom ETA from uploader component and add uploading speed.


Due to the risks of something breaking this is **100%** test covered (unit tests) and additionally added component tests for it.