### PR TITLE
chore: prepare release of v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 -->
 # Changelog
 
+## [v1.9.1](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.9.1) \(2025-03-20\)
+
+### Fixed
+* fix(upload): do not retry when insufficient storage but when locked [\#1657](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1657) \([susnux](https://github.com/susnux)\)
+* fix(uploader): only set mtime if valid value is passed [\#1666](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1666) \([susnux](https://github.com/susnux)\)
+
+## Changed
+* Updated translations
+* Updated Axios to version 1.8.3
+* Updated development dependencies
+* chore(i18n): adding hint for translators [\#1643](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1643) \([rakekniven](https://github.com/rakekniven)\)
+* chore(i18n): Fixes wrong translations syntax [\#1645](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1645) \([rakekniven](https://github.com/rakekniven)\)
+
 ## [v1.9.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.9.0) \(2025-03-04\)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/upload",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Nextcloud file upload client",
   "keywords": [
     "nextcloud",


### PR DESCRIPTION
### Fixed
* fix(upload): do not retry when insufficient storage but when locked [\#1657](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1657) \([susnux](https://github.com/susnux)\)
* fix(uploader): only set mtime if valid value is passed [\#1666](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1666) \([susnux](https://github.com/susnux)\)

## Changed
* Updated translations
* Updated Axios to version 1.8.3
* Updated development dependencies
* chore(i18n): adding hint for translators [\#1643](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1643) \([rakekniven](https://github.com/rakekniven)\)
* chore(i18n): Fixes wrong translations syntax [\#1645](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1645) \([rakekniven](https://github.com/rakekniven)\)
