### PR TITLE
chore: prepare v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 -->
 # Changelog
 
+## [v1.11.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.11.0) \(2025-09-10\)
+### Added
+* feat(button): Added option to not have label on New button [\#1831](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1831) \([joj0r](https://github.com/joj0r)\)
+
+### Fixed
+* fix(UploadPicker): upload folders icon color [\#1822](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1822) \([skjnldsv](https://github.com/skjnldsv)\)
+
+### Changed
+* refactor: split `vue` and `dialogs` sub modules to prepare for library splitting [\#1816](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1816) \([ShGKme](https://github.com/ShGKme)\)
+* chore(package.json): update engines and add devEngines [\#1820](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1820) \([ShGKme](https://github.com/ShGKme)\)
+* Updated translations
+
 ## [v1.10.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.10.0) \(2025-05-05\)
 
 ### Added
@@ -33,16 +45,16 @@
 ## [v1.9.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.9.0) \(2025-03-04\)
 
 ### Added
-* feat: add assembling status to UploadPicker by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1530
-* feat(UploadPicker): Allow to set color to primary by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1606
-* feat(uploader): add ETA implementation with upload speed information by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1627
+* feat: add assembling status to UploadPicker [\#1530](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1530) \([skjnldsv](https://github.com/skjnldsv)\)
+* feat(UploadPicker): Allow to set color to primary [\#1606](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1606) \([susnux](https://github.com/susnux)\)
+* feat(uploader): add ETA implementation with upload speed information [\#1627](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1627) \([susnux](https://github.com/susnux)\)
 
 ### Fixed
-* fix: fix eslint scripts by @Koc in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1518
-* fix: include non conflicting files for upload by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1615
-* fix(conflictpicker): force background on sticky header by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1635
-* fix(uploader): Correctly (re)set progress on upload by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1603
-* fix(uploader): properly propagate upload cancelled status by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1617
+* fix: fix eslint scripts [\#1518](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1518) \([Koc](https://github.com/Koc)\)
+* fix: include non conflicting files for upload [\#1615](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1615) \([susnux](https://github.com/susnux)\)
+* fix(conflictpicker): force background on sticky header [\#1635](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1635) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix(uploader): Correctly (re)set progress on upload [\#1603](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1603) \([susnux](https://github.com/susnux)\)
+* fix(uploader): properly propagate upload cancelled status [\#1617](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1617) \([susnux](https://github.com/susnux)\)
 
 ### Changed
 * Updated translations
@@ -54,8 +66,8 @@
 * chore(deps): bump dompurify from 3.1.6 to 3.2.4
 * chore(deps): bump elliptic from 6.6.0 to 6.6.1
 * chore(deps): bump p-queue from 8.0.1 to 8.1.0
-* test: adjust config for vitest v3 and await expect by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1600
-* test: silence console output when testing logger by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1602
+* test: adjust config for vitest v3 and await expect [\#1600](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1600) \([susnux](https://github.com/susnux)\)
+* test: silence console output when testing logger [\#1602](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1602) \([susnux](https://github.com/susnux)\)
 
 ## [v1.8.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.8.0) \(2025-01-20\)
 
@@ -86,19 +98,19 @@
 ## [v1.7.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.7.0) \(2024-11-13\)
 
 ### Added
-* feat: Add `uploadConflictHandler` to handle conflict resolution by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1442
-* feat: Respect parallel count config by @provokateurin in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1444
+* feat: Add `uploadConflictHandler` to handle conflict resolution [\#1442](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1442) \([susnux](https://github.com/susnux)\)
+* feat: Respect parallel count config [\#1444](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1444) \([provokateurin](https://github.com/provokateurin)\)
 
 ### Fixed
-* fix: Fix adding children to directory (file tree) for batch uploading by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1463
+* fix: Fix adding children to directory (file tree) for batch uploading [\#1463](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1463) \([susnux](https://github.com/susnux)\)
 
 ### Changed
-* chore: Add more debug logging to trace errors by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1432
-* chore(deps): Bump @nextcloud/dialogs from 5.3.7 to 6.0.1 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1469
-* chore(deps): Bump @nextcloud/files from 3.9.0 to 3.9.1 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1452
-* chore(deps): Bump crypto-browserify from 3.12.0 to 3.12.1 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1450
-* chore(deps): Bump elliptic from 6.5.7 to 6.6.0 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1461
-* test: Cleanup test setup by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1441
+* chore: Add more debug logging to trace errors [\#1432](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1432) \([susnux](https://github.com/susnux)\)
+* chore(deps): Bump @nextcloud/dialogs from 5.3.7 to 6.0.1 [\#1469](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1469) \([dependabot](https://github.com/dependabot)\)
+* chore(deps): Bump @nextcloud/files from 3.9.0 to 3.9.1 [\#1452](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1452) \([dependabot](https://github.com/dependabot)\)
+* chore(deps): Bump crypto-browserify from 3.12.0 to 3.12.1 [\#1450](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1450) \([dependabot](https://github.com/dependabot)\)
+* chore(deps): Bump elliptic from 6.5.7 to 6.6.0 [\#1461](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1461) \([dependabot](https://github.com/dependabot)\)
+* test: Cleanup test setup [\#1441](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1441) \([susnux](https://github.com/susnux)\)
 * Translations updates
 
 ## New Contributors
@@ -153,9 +165,9 @@
 
 ## [v1.4.3](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.4.3) \(2024-08-07\)
 ### Fixed
-* fix: Always request current content when triggering a menu entry by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1313
-* fix: Remove outdated languages that are blocking the real translations by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1282
-* fix(UploadPicker): Do not hardcode the height but use the CSS variable by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1309
+* fix: Always request current content when triggering a menu entry [\#1313](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1313) \([susnux](https://github.com/susnux)\)
+* fix: Remove outdated languages that are blocking the real translations [\#1282](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1282) \([susnux](https://github.com/susnux)\)
+* fix(UploadPicker): Do not hardcode the height but use the CSS variable [\#1309](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1309) \([susnux](https://github.com/susnux)\)
 
 ## What's Changed
 * chore: Bump @nextcloud/files from 3.5.1 to 3.7.0 by @dependabot
@@ -174,8 +186,8 @@
 * chore: Bump typescript from 5.4.5 to 5.5.4 by @dependabot
 * chore: Bump vite from 5.3.3 to 5.3.5 by @dependabot
 * chore: Bump webdav from 5.6.0 to 5.7.1 by @dependabot
-* chore: monitor bundle size with codecov by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1290
-* feat: add cypress selectors for new menu entries by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1289
+* chore: monitor bundle size with codecov [\#1290](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1290) \([skjnldsv](https://github.com/skjnldsv)\)
+* feat: add cypress selectors for new menu entries [\#1289](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1289) \([skjnldsv](https://github.com/skjnldsv)\)
 * Translations updates
 
 **Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.4.2...v1.4.3
@@ -224,33 +236,33 @@
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.2.0...v1.3.0)
 
 ### Added
-* feat: Implement upload on public shares using dav endpoint v2 by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1225
+* feat: Implement upload on public shares using dav endpoint v2 [\#1225](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1225) \([susnux](https://github.com/susnux)\)
 
 ### Changed
-* refactor: Only import from nextcloud-axios not axios directly by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1224
+* refactor: Only import from nextcloud-axios not axios directly [\#1224](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1224) \([susnux](https://github.com/susnux)\)
 * Updated translations
-* chore(deps): Bump @nextcloud/files from 3.3.1 to 3.4.0 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1220
-* chore(deps): Bump @types/node to 20.14.2 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1227
+* chore(deps): Bump @nextcloud/files from 3.3.1 to 3.4.0 [\#1220](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1220) \([dependabot](https://github.com/dependabot)\)
+* chore(deps): Bump @types/node to 20.14.2 [\#1227](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1227) \([dependabot](https://github.com/dependabot)\)
 
 ## [v1.2.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.2.0) (2024-05-23)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.1.1...v1.2.0)
 
 ### Added
-* feat(NodesPicker): Add support for FileSystemEntry by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1165
-* feat(ConflictPicker): Allow to use `FileSystemEntry` by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1166
-* feat: Allow to upload directories and allow bulk upload by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1175
-* feat: Split new-menu entries into `upload` `new` and *other* by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1206
-* feat(ConflictPicker): refresh preview on etag change by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1214
+* feat(NodesPicker): Add support for FileSystemEntry [\#1165](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1165) \([susnux](https://github.com/susnux)\)
+* feat(ConflictPicker): Allow to use `FileSystemEntry` [\#1166](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1166) \([susnux](https://github.com/susnux)\)
+* feat: Allow to upload directories and allow bulk upload [\#1175](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1175) \([susnux](https://github.com/susnux)\)
+* feat: Split new-menu entries into `upload` `new` and *other* [\#1206](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1206) \([susnux](https://github.com/susnux)\)
+* feat(ConflictPicker): refresh preview on etag change [\#1214](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1214) \([skjnldsv](https://github.com/skjnldsv)\)
 
 ### Fixed
-* fix(ConflictPicker): Ensure component works also if browser does not support FileSystemEntry by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1171
-* fix(ConflictPicker): Allow to set recursive upload note + fix types for conflict utils functions by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1176
-* fix(docs): Add parameter docs for `getUploader` by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1207
+* fix(ConflictPicker): Ensure component works also if browser does not support FileSystemEntry [\#1171](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1171) \([susnux](https://github.com/susnux)\)
+* fix(ConflictPicker): Allow to set recursive upload note + fix types for conflict utils functions [\#1176](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1176) \([susnux](https://github.com/susnux)\)
+* fix(docs): Add parameter docs for `getUploader` [\#1207](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1207) \([susnux](https://github.com/susnux)\)
 
 ### Changed
 * Updated translations
-* fix(tests): Add tests for filesystem helpers by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1174
-* fix: Refactor logger and fix badges in README by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1173
+* fix(tests): Add tests for filesystem helpers [\#1174](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1174) \([susnux](https://github.com/susnux)\)
+* fix: Refactor logger and fix badges in README [\#1173](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1173) \([susnux](https://github.com/susnux)\)
 * build(deps): Bump @nextcloud/dialogs to 5.3.1
 * build(deps): Bump @nextcloud/auth to 2.3.0
 * build(deps): Bump @nextcloud/router to 3.0.1
@@ -263,8 +275,8 @@
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.1.0...v1.1.1)
 
 ### :bug: Fixed bugs
-* fix: Drop dependency on moment.js by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1155
-* fix(upload): Do not read chunks into memory but just stream file chunks by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1153
+* fix: Drop dependency on moment.js [\#1155](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1155) \([susnux](https://github.com/susnux)\)
+* fix(upload): Do not read chunks into memory but just stream file chunks [\#1153](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1153) \([susnux](https://github.com/susnux)\)
 
 ### Changed
 * Updated development dependencies
@@ -275,13 +287,13 @@
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.0.5...v1.1.0)
 
 ### Features :rocket:
-* feat: allow to specify the root of an upload by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1131
-* feat: allow to specify forbidden characters by @arublov in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1132
+* feat: allow to specify the root of an upload [\#1131](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1131) \([skjnldsv](https://github.com/skjnldsv)\)
+* feat: allow to specify forbidden characters [\#1132](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1132) \([arublov](https://github.com/arublov)\)
 
 ### Bug Fixes :bug:
-* fix: conflict picker by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1123
-* fix: migrate conflictpicker to NcDialog and remove incorrect semantic closing icon by @emoral435 in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1113
-* fix(ConflictPicker): Use action slot instead of custom wrapper for buttons by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1117
+* fix: conflict picker [\#1123](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1123) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix: migrate conflictpicker to NcDialog and remove incorrect semantic closing icon [\#1113](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1113) \([emoral435](https://github.com/emoral435)\)
+* fix(ConflictPicker): Use action slot instead of custom wrapper for buttons [\#1117](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1117) \([susnux](https://github.com/susnux)\)
 
 ### Changed
 * build(deps-dev): Bump @cypress/vue2 from 2.0.1 to 2.1.0 by @dependabot
@@ -305,35 +317,35 @@
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.0.4...v1.0.5)
 
 ### :bug: Fixed bugs
-* fix: also add `X-OC-Mtime` header to final chunks move by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1038
-* fix: properly handle chunk upload failure by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1042
-* fix: Add upload progress for non-chunked uploads by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1080
-* fix: do not try to slice in chunk larger than the File itself by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1057
-* fix: Some issues with `package.json` by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1088
+* fix: also add `X-OC-Mtime` header to final chunks move [\#1038](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1038) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix: properly handle chunk upload failure [\#1042](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1042) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix: Add upload progress for non-chunked uploads [\#1080](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1080) \([susnux](https://github.com/susnux)\)
+* fix: do not try to slice in chunk larger than the File itself [\#1057](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1057) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix: Some issues with `package.json` [\#1088](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1088) \([susnux](https://github.com/susnux)\)
 
 ### Changed
 * Require NPM v10 to be compatible with LTS Node 20
 * Updated translations
 * Updated dependencies
 * Updated development dependencies
-* Migrate cypress config to use to vite by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/999
-* chore: add block-unconventional-commits.yml by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1082
+* Migrate cypress config to use to vite [\#999](https://github.com/nextcloud-libraries/nextcloud-upload/pull/999) \([susnux](https://github.com/susnux)\)
+* chore: add block-unconventional-commits.yml [\#1082](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1082) \([skjnldsv](https://github.com/skjnldsv)\)
 
 ## [v1.0.4](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.0.4) (2023-12-15)
 
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.0.3...v1.0.4)
 
 ### :bug: Fixed bugs
-* fix(uploader): encode destination by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/996
-* fix(uploader): fix PUT content-type by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1002
-* fix(UploadPicker): Add label for upload progress and connect progress with description [a11y] by @susnux in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1000
+* fix(uploader): encode destination [\#996](https://github.com/nextcloud-libraries/nextcloud-upload/pull/996) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix(uploader): fix PUT content-type [\#1002](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1002) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix(UploadPicker): Add label for upload progress and connect progress with description [a11y] [\#1000](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1000) \([susnux](https://github.com/susnux)\)
 
 ### Dependencies & translations
-* build(deps-dev): Bump @types/node from 20.10.3 to 20.10.4 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/990
-* build(deps): Bump actions/upload-artifact from 3 to 4 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/998
-* build(deps): Bump p-queue from 7.4.1 to 8.0.1 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/997
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/1003
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/993
+* build(deps-dev): Bump @types/node from 20.10.3 to 20.10.4 [\#990](https://github.com/nextcloud-libraries/nextcloud-upload/pull/990) \([dependabot](https://github.com/dependabot)\)
+* build(deps): Bump actions/upload-artifact from 3 to 4 [\#998](https://github.com/nextcloud-libraries/nextcloud-upload/pull/998) \([dependabot](https://github.com/dependabot)\)
+* build(deps): Bump p-queue from 7.4.1 to 8.0.1 [\#997](https://github.com/nextcloud-libraries/nextcloud-upload/pull/997) \([dependabot](https://github.com/dependabot)\)
+* Updates for project Nextcloud upload library [\#1003](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1003) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#993](https://github.com/nextcloud-libraries/nextcloud-upload/pull/993) \([transifex-integration](https://github.com/transifex-integration)\)
 
 ## [v1.0.3](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.0.3) (2023-12-07)
 
@@ -346,22 +358,22 @@
 ## [v1.0.2](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.0.2) (2023-11-29)
 
 ## What's Changed
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/961
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/962
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/963
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/964
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/965
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/966
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/967
-* enable dependabot by @szaimen in https://github.com/nextcloud-libraries/nextcloud-upload/pull/969
-* build(deps-dev): Bump @types/node from 20.9.0 to 20.10.0 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/972
-* build(deps-dev): Bump typedoc from 0.25.3 to 0.25.4 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/978
-* build(deps): Bump @nextcloud/dialogs from 5.0.0-beta.6 to 5.0.3 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/976
-* Updates for project Nextcloud upload library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-upload/pull/968
-* build(deps): Bump peter-evans/create-or-update-comment from 3.0.2 to 3.1.0 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/970
-* build(deps): Bump cypress-io/github-action from 5.8.3 to 6.6.0 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/971
-* build(deps): Bump actions/checkout from 3 to 4 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/974
-* build(deps): Bump actions/setup-node from 3 to 4 by @dependabot in https://github.com/nextcloud-libraries/nextcloud-upload/pull/973
+* Updates for project Nextcloud upload library [\#961](https://github.com/nextcloud-libraries/nextcloud-upload/pull/961) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#962](https://github.com/nextcloud-libraries/nextcloud-upload/pull/962) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#963](https://github.com/nextcloud-libraries/nextcloud-upload/pull/963) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#964](https://github.com/nextcloud-libraries/nextcloud-upload/pull/964) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#965](https://github.com/nextcloud-libraries/nextcloud-upload/pull/965) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#966](https://github.com/nextcloud-libraries/nextcloud-upload/pull/966) \([transifex-integration](https://github.com/transifex-integration)\)
+* Updates for project Nextcloud upload library [\#967](https://github.com/nextcloud-libraries/nextcloud-upload/pull/967) \([transifex-integration](https://github.com/transifex-integration)\)
+* enable dependabot [\#969](https://github.com/nextcloud-libraries/nextcloud-upload/pull/969) \([szaimen](https://github.com/szaimen)\)
+* build(deps-dev): Bump @types/node from 20.9.0 to 20.10.0 [\#972](https://github.com/nextcloud-libraries/nextcloud-upload/pull/972) \([dependabot](https://github.com/dependabot)\)
+* build(deps-dev): Bump typedoc from 0.25.3 to 0.25.4 [\#978](https://github.com/nextcloud-libraries/nextcloud-upload/pull/978) \([dependabot](https://github.com/dependabot)\)
+* build(deps): Bump @nextcloud/dialogs from 5.0.0-beta.6 to 5.0.3 [\#976](https://github.com/nextcloud-libraries/nextcloud-upload/pull/976) \([dependabot](https://github.com/dependabot)\)
+* Updates for project Nextcloud upload library [\#968](https://github.com/nextcloud-libraries/nextcloud-upload/pull/968) \([transifex-integration](https://github.com/transifex-integration)\)
+* build(deps): Bump peter-evans/create-or-update-comment from 3.0.2 to 3.1.0 [\#970](https://github.com/nextcloud-libraries/nextcloud-upload/pull/970) \([dependabot](https://github.com/dependabot)\)
+* build(deps): Bump cypress-io/github-action from 5.8.3 to 6.6.0 [\#971](https://github.com/nextcloud-libraries/nextcloud-upload/pull/971) \([dependabot](https://github.com/dependabot)\)
+* build(deps): Bump actions/checkout from 3 to 4 [\#974](https://github.com/nextcloud-libraries/nextcloud-upload/pull/974) \([dependabot](https://github.com/dependabot)\)
+* build(deps): Bump actions/setup-node from 3 to 4 [\#973](https://github.com/nextcloud-libraries/nextcloud-upload/pull/973) \([dependabot](https://github.com/dependabot)\)
 
 ## New Contributors
 * @szaimen made their first contribution in https://github.com/nextcloud-libraries/nextcloud-upload/pull/969

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,7 @@ export type { IDirectory, Directory } from './utils/fileTree.ts'
 
 export { getUploader, upload } from './getUploader.ts'
 export { Upload, Status as UploadStatus } from './upload.ts'
-export { Uploader, UploaderStatus, EtaStatus, } from './uploader/index.ts'
+export { Uploader, UploaderStatus, EtaStatus } from './uploader/index.ts'
 export { getConflicts, hasConflict } from './utils/conflicts.ts'
 
 export type { ConflictResolutionResult, ConflictPickerOptions } from './dialogs/openConflictPicker.ts'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/upload",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Nextcloud file upload client",
   "keywords": [
     "nextcloud",


### PR DESCRIPTION
## [v1.11.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.11.0) \(2025-09-10\)
### Added
* feat(button): Added option to not have label on New button [\#1831](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1831) \([joj0r](https://github.com/joj0r)\)

### Fixed
* fix(UploadPicker): upload folders icon color [\#1822](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1822) \([skjnldsv](https://github.com/skjnldsv)\)

### Changed
* refactor: split `vue` and `dialogs` sub modules to prepare for library splitting [\#1816](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1816) \([ShGKme](https://github.com/ShGKme)\)
* chore(package.json): update engines and add devEngines [\#1820](https://github.com/nextcloud-libraries/nextcloud-upload/pull/1820) \([ShGKme](https://github.com/ShGKme)\)
* Updated translations