### PR TITLE
chore: prepare v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 -->
 # Changelog
 
+## [v1.12.0](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.12.0) \(2026-09-02\)
+
+### Added
+
+* Simplify the file conflict dialog [\#2151](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2151) \([jancborchardt](https://github.com/jancborchardt)\)
+
+### Fixed
+
+* fix: add response to upload when assembling chunks [\#2092](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2092) \([Antreesy](https://github.com/Antreesy)\)
+* fix: InvalidFilenameDialog value binding, test exclusions, and CI flakes [\#2107](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2107) \([skjnldsv](https://github.com/skjnldsv)\)
+
+### Changed
+
+* Update upload icon, use outlined variant for upload-folder [\#2099](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2099) \([AndyScherzinger](https://github.com/AndyScherzinger)\)
+* fix: prevent file upload input from receiving keyboard tab focus [\#2138](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2138) \([kristian-zendato](https://github.com/kristian-zendato)\)
+* Updates for project Nextcloud upload library [\#2021](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2021), [\#2024](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2024), [\#2031](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2031), [\#2033](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2033), [\#2049](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2049), [\#2058](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2058), [\#2086](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2086), [\#2154](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2154), [\#2155](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2155), [\#2156](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2156), [\#2157](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2157), [\#2158](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2158), [\#2160](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2160), [\#2164](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2164), [\#2166](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2166), [\#2172](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2172), [\#2176](https://github.com/nextcloud-libraries/nextcloud-upload/pull/2176) \([transifex-integration[bot]](https://github.com/transifex-integration[bot])\)
+
 ## [v1.11.1](https://github.com/nextcloud-libraries/nextcloud-upload/tree/v1.11.1) \(2026-01-14\)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/upload",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/upload",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Nextcloud file upload client",
   "keywords": [
     "nextcloud",


### PR DESCRIPTION
## Summary

Minor release prep: bump version 1.11.1 → 1.12.0 and add CHANGELOG.md entry.

Changes since v1.11.1:
- Added: file conflict dialog simplification (#2151)
- Fixed: chunked upload response missing (#2092), InvalidFilenameDialog binding/CI flakes (#2107)
- Changed: upload icon variant (#2099), upload input tab focus fix (#2138), transifex translation updates

## AI disclosure

Version bump and changelog entry were prepared with Claude Code (AI-assisted), per the [Nextcloud AI contribution policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md). Changelog content is derived from GitHub's auto-generated release notes for this range, formatted to match existing CHANGELOG.md conventions.

## Testing notes

- Verify CHANGELOG.md entry matches PRs merged since v1.11.1 (compare: https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.11.1...main)
- Verify package.json / package-lock.json version is 1.12.0 only, no unrelated diff
- On merge, cut GitHub release `v1.12.0` with auto-generated notes to trigger npm publish workflow